### PR TITLE
Add contributor docs and CI automation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+# charset intentionally not set here, existing files mix BOM and no-BOM, not touching that for now
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+
+[*.xaml]
+indent_style = space
+indent_size = 4
+
+[*.{csproj,props,targets,sln,slnx}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,json,md}]
+indent_style = space
+indent_size = 2

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to FluentSensors
+
+Thanks for wanting to contribute. FluentSensors is a solo hobby project, so response times may vary.
+
+### Before you start
+
+For anything beyond a small fix, open an issue first to talk through the approach before writing code. Saves everyone rework.
+
+## Getting set up
+
+1. [Fork](https://github.com/cechout/fluent-sensors/fork) the repository
+2. Clone your fork
+
+```
+   git clone https://github.com/<your-username>/fluent-sensors.git
+   ```
+
+3. Create a branch off `main`, named `feature/xxx`, `fix/xxx`, or `chore/xxx`
+
+```
+   git checkout -b feature/your-feature-name
+   ```
+
+4. Make your changes, then push and [open a pull request](https://github.com/cechout/fluent-sensors/compare) against `main`
+
+See the "How to Build" section in the [README](README.md) for build prerequisites.
+
+Pull requests run an automated build check (Windows, x64, Release). Make sure it is green before requesting review.
+
+## What we accept
+
+* keep pull requests focused on one thing, and link the issue it addresses if there is one
+* if it is a bug fix, check whether the same problem shows up elsewhere in the codebase before submitting
+* avoid reformatting or restructuring code you are not otherwise touching, keep the diff to what you actually changed
+
+## A few more things
+
+AI tools are completely fine to use for writing code. Just review what you submit and be able to explain why it is written the way it is, PRs that are clearly unreviewed AI output will not get merged.
+
+Commit messages should be short, imperative, single sentence, English, no body. Branch history does not need to be pristine either, commits get squashed into one on merge anyway.
+

--- a/.github/README.md
+++ b/.github/README.md
@@ -7,7 +7,7 @@ There aren't many hardware monitoring tools that actually look native on Windows
 
 ## ✨ Features
 
-* **The Engine (LibreHardwareMonitorLib):** Reads all sensors, CPU, GPU, RAM, storage, network, using the open source [LibreHardwareMonitorLib](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) library. *Note: this library has some limitations and can struggle to read certain sensors, like the ones from integrated graphics cards.*
+* **The Engine:** Reads all sensors, CPU, GPU, RAM, storage, network, using the open source [LibreHardwareMonitorLib](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) library. *Note: this library has some limitations and can struggle to read certain sensors, like the ones from integrated graphics cards.*
 * **The Interface (WinUI 3 + MVVM):** Built with the Windows App SDK for the native Windows 11 Fluent Design look, and using the Model-View-ViewModel pattern.
 * **Sensors Page:** Shows every sensor found, with the option to pin your most important ones to a separate, always-visible widget window.
 * **Hardware View Page:** Shows every hardware component LibreHardwareMonitorLib finds as its own tab, so multiple CPUs, GPUs, or drives each get their own tab. Each tab shows the most important graphs for that component, plus static info like cache size, RAM speed, or storage type.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+### Supported versions
+
+Only the latest released version is supported with security fixes.
+
+### Reporting a vulnerability
+
+Please do not open a public issue for security vulnerabilities.
+
+Use GitHub's private vulnerability reporting instead: go to the `Security` tab of this repository and select "Report a vulnerability"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## What does this change
+
+<!-- short description of what changed and why -->
+
+## Checklist
+
+- [ ] Builds locally (x64, Release)
+- [ ] Comments and code are in English

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+# security scanning via CodeQL, advanced setup with manual build mode
+#
+# autobuild is not used here, WinUI3 needs the same explicit build pass release.yml documents
+# (MarkupCompilePass2 needs a full Build pass to resolve x:Bind LocalAssembly types)
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "24 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: initialize codeql
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          build-mode: manual
+
+      - name: setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: build win-x64
+        run: dotnet build FluentSensors/FluentSensors.csproj -c Release -p:Platform=x64 -r win-x64 --self-contained true
+
+      - name: perform codeql analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,48 @@
+# validates that a pull request actually compiles before review
+# deliberately lighter than release.yml: build only, no publish/installer step, not tied to a version tag
+name: pr build check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+          cache: true
+          cache-dependency-path: FluentSensors/FluentSensors.csproj
+
+      # same build command release.yml relies on, a single full build pass is enough here
+      # since there is no publish step after it
+      - name: build win-x64
+        run: dotnet build FluentSensors/FluentSensors.csproj -c Release -p:Platform=x64 -r win-x64 --self-contained true
+
+  format:
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+          cache: true
+          cache-dependency-path: FluentSensors/FluentSensors.csproj
+
+      # scoped to whitespace only, matches the new .editorconfig, not style/analyzers
+      # non blocking for now, flip continue-on-error to false once confirmed clean against main
+      - name: dotnet format whitespace check
+        continue-on-error: true
+        run: dotnet format whitespace FluentSensors/FluentSensors.csproj --verify-no-changes --verbosity diagnostic

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -45,4 +45,4 @@ jobs:
       # non blocking for now, flip continue-on-error to false once confirmed clean against main
       - name: dotnet format whitespace check
         continue-on-error: true
-        run: dotnet format whitespace FluentSensors/FluentSensors.csproj --verify-no-changes --verbosity diagnostic
+        run: dotnet format whitespace FluentSensors/FluentSensors.csproj -p:Platform=x64 --verify-no-changes --verbosity diagnostic


### PR DESCRIPTION
Adds a build check for pull requests, CodeQL scanning, Dependabot for NuGet and Actions, plus a .editorconfig. README, CONTRIBUTING and SECURITY moved into .github/.

Format check and CodeQL are new and unverified against the existing codebase, both non blocking for now, may need follow up tweaks.