### PR TITLE
Group minor and patch updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What does this change

Adds the same minor and patch grouping already used for nuget to the github-actions ecosystem, so routine action bumps land in one pr instead of several.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English