### PR TITLE
Rework the taskbar flyout: backdrop, sizing, animation and settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,11 @@ bld/
 .antigravity/
 .gemini/
 
+# Claude Code (local agent guidance, not shared)
+/CLAUDE.md
+/CLAUDE.local.md
+.claude/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -13,10 +13,9 @@
             </ResourceDictionary.MergedDictionaries>
 
             <ResourceDictionary.ThemeDictionaries>
-                <!--  ===================================================================  -->
-                <!--  DARK MODE (Default Theme Dictionary)  -->
+                <!--  === DARK MODE (Default Theme Dictionary) ===  -->
+
                 <!--  Base Taskbar Background: #202020 (32)  -->
-                <!--  ===================================================================  -->
                 <ResourceDictionary x:Key="Default">
                     <!--  1. Taskbar Button Normal Hover & Pressed Backgrounds (Alpha White on #202020)  -->
                     <!--  Hover -> Target #2D2D2D (45): Alpha 15 (0x0F) -> #0FFFFFFF  -->
@@ -48,14 +47,23 @@
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="Transparent" />
 
                     <!--  4. Flyout Window Styling (Dark Mode)  -->
-                    <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#202020" />
+                    <!--  Window Base -> Target #222222  -->
+                    <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#222222" />
                     <SolidColorBrush x:Key="FlyoutWindowBorderBrush" Color="#383838" />
+
+                    <!--  5. Flyout Graphs Content Background (Dark Mode)  -->
+                    <!--  Graphs Content -> Target #292929 (41) over window base #222222 (34): Alpha 8 (0x08) White -> #08FFFFFF  -->
+                    <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="#08FFFFFF" />
+
+                    <!--  6. Flyout Bottom Bar (Dark Mode)  -->
+                    <!--  Bottom Bar directly uses window base #222222  -->
+                    <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="Transparent" />
                 </ResourceDictionary>
 
-                <!--  ===================================================================  -->
-                <!--  LIGHT MODE Theme Dictionary  -->
+
+                <!--  === LIGHT MODE Theme Dictionary ===  -->
+
                 <!--  Base Taskbar Background: #EDEDED (237)  -->
-                <!--  ===================================================================  -->
                 <ResourceDictionary x:Key="Light">
                     <!--  1. Taskbar Button Normal Hover & Pressed Backgrounds (Alpha White on #EDEDED)  -->
                     <!--  Hover -> Target #F7F7F7 (247): Alpha 142 (0x8E) -> #8EFFFFFF  -->
@@ -89,8 +97,15 @@
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="#E7E7E7" />
 
                     <!--  4. Flyout Window Styling (Light Mode)  -->
+                    <!--  Window Base -> Target #F2F2F2  -->
                     <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#F2F2F2" />
                     <SolidColorBrush x:Key="FlyoutWindowBorderBrush" Color="#BFBFBF" />
+
+                    <!--  5. Flyout Graphs Content Background (Light Mode)  -->
+                    <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="Transparent" />
+
+                    <!--  6. Flyout Bottom Bar (Light Mode)  -->
+                    <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="Transparent" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>

--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -64,7 +64,7 @@
                     <!--  5. Flyout Graphs Overlay (Dark Mode)  -->
                     <!--  only used in the blur modes, where it lifts the graphs area off the glass  -->
                     <!--  (the opaque mode takes its content color from FlyoutWindowBackground and uses no overlay)  -->
-                    <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="#08FFFFFF" />
+                    <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="#0AFFFFFF" />
 
                     <!--  6. Flyout Bottom Bar (Dark Mode)  -->
                     <!--  Bottom Bar -> literal #1C1C1C, reads as #222222 here  -->
@@ -72,9 +72,12 @@
                     <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="#1C1C1C" />
 
                     <!--  7. Flyout Bottom Bar Separator (Dark Mode)  -->
-                    <!--  1px stroke between content area and bottom bar, solid in every backdrop mode  -->
+                    <!--  1px stroke between content area and bottom bar  -->
                     <!--  literal #181818, reads as #1E1E1E here  -->
                     <SolidColorBrush x:Key="FlyoutBottomBarSeparatorBrush" Color="#181818" />
+                    <!--  the same stroke in the blur modes, where the native line is translucent and darkens the  -->
+                    <!--  material instead of covering it, so it keeps letting the backdrop through  -->
+                    <SolidColorBrush x:Key="FlyoutBottomBarSeparatorOnGlassBrush" Color="#1F000000" />
                 </ResourceDictionary>
 
 
@@ -126,16 +129,19 @@
                     <!--  5. Flyout Graphs Overlay (Light Mode)  -->
                     <!--  only used in the blur modes, where it lifts the graphs area off the glass  -->
                     <!--  (the opaque mode takes its content color from FlyoutWindowBackground and uses no overlay)  -->
-                    <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="#47FFFFFF" />
+                    <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="#38FFFFFF" />
 
                     <!--  6. Flyout Bottom Bar (Light Mode)  -->
                     <!--  Bottom Bar -> Target #EDEDED (237), opaque and independent of the content area  -->
                     <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="#EDEDED" />
 
                     <!--  7. Flyout Bottom Bar Separator (Light Mode)  -->
-                    <!--  1px stroke between content area and bottom bar, solid in every backdrop mode  -->
+                    <!--  1px stroke between content area and bottom bar  -->
                     <!--  literal #DEDEDE, reads as #DDDDDD here  -->
                     <SolidColorBrush x:Key="FlyoutBottomBarSeparatorBrush" Color="#DEDEDE" />
+                    <!--  the same stroke in the blur modes, where the native line is translucent and darkens the  -->
+                    <!--  material instead of covering it, so it keeps letting the backdrop through  -->
+                    <SolidColorBrush x:Key="FlyoutBottomBarSeparatorOnGlassBrush" Color="#13000000" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>

--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -97,14 +97,16 @@
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="#E7E7E7" />
 
                     <!--  4. Flyout Window Styling (Light Mode)  -->
-                    <!--  Window Base -> Target #F2F2F2  -->
-                    <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#F2F2F2" />
+                    <!--  Window Base -> Target #EDEDED (237)  -->
+                    <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#EDEDED" />
                     <SolidColorBrush x:Key="FlyoutWindowBorderBrush" Color="#BFBFBF" />
 
                     <!--  5. Flyout Graphs Content Background (Light Mode)  -->
-                    <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="Transparent" />
+                    <!--  Graphs Content -> Target #F2F2F2 (242) over window base #EDEDED (237): Alpha 71 (0x47) White -> #47FFFFFF  -->
+                    <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="#47FFFFFF" />
 
                     <!--  6. Flyout Bottom Bar (Light Mode)  -->
+                    <!--  Bottom Bar directly uses window base #EDEDED  -->
                     <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="Transparent" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>

--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -13,6 +13,7 @@
             </ResourceDictionary.MergedDictionaries>
 
             <ResourceDictionary.ThemeDictionaries>
+
                 <!--  === DARK MODE (Default Theme Dictionary) ===  -->
 
                 <!--  Base Taskbar Background: #202020 (32)  -->
@@ -47,17 +48,33 @@
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="Transparent" />
 
                     <!--  4. Flyout Window Styling (Dark Mode)  -->
-                    <!--  Window Base -> Target #222222  -->
-                    <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#222222" />
-                    <SolidColorBrush x:Key="FlyoutWindowBorderBrush" Color="#383838" />
+                    <!--
+                        the dark literals sit a few levels below the tone they actually show; they were dialed in
+                        by comparing screenshots with the native Windows surfaces, where dark values read back
+                        lighter than they were written
+                        that offset belongs to the display it was tuned on; another monitor measures its own
+                        numbers, so the second value on each line is what was seen here and not a spec
+                    -->
+                    <!--  Content Area -> literal #242424, reads as #292929 here, opaque  -->
+                    <!--  (the bottom bar paints its own color, see 6)  -->
+                    <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#242424" />
+                    <!--  Window Border -> literal #464646, reads as #484848 here  -->
+                    <SolidColorBrush x:Key="FlyoutWindowBorderBrush" Color="#464646" />
 
-                    <!--  5. Flyout Graphs Content Background (Dark Mode)  -->
-                    <!--  Graphs Content -> Target #292929 (41) over window base #222222 (34): Alpha 8 (0x08) White -> #08FFFFFF  -->
+                    <!--  5. Flyout Graphs Overlay (Dark Mode)  -->
+                    <!--  only used in the blur modes, where it lifts the graphs area off the glass  -->
+                    <!--  (the opaque mode takes its content color from FlyoutWindowBackground and uses no overlay)  -->
                     <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="#08FFFFFF" />
 
                     <!--  6. Flyout Bottom Bar (Dark Mode)  -->
-                    <!--  Bottom Bar directly uses window base #222222  -->
-                    <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="Transparent" />
+                    <!--  Bottom Bar -> literal #1C1C1C, reads as #222222 here  -->
+                    <!--  opaque and independent of the content area  -->
+                    <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="#1C1C1C" />
+
+                    <!--  7. Flyout Bottom Bar Separator (Dark Mode)  -->
+                    <!--  1px stroke between content area and bottom bar, solid in every backdrop mode  -->
+                    <!--  literal #181818, reads as #1E1E1E here  -->
+                    <SolidColorBrush x:Key="FlyoutBottomBarSeparatorBrush" Color="#181818" />
                 </ResourceDictionary>
 
 
@@ -97,17 +114,28 @@
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="#E7E7E7" />
 
                     <!--  4. Flyout Window Styling (Light Mode)  -->
-                    <!--  Window Base -> Target #EDEDED (237)  -->
-                    <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#EDEDED" />
-                    <SolidColorBrush x:Key="FlyoutWindowBorderBrush" Color="#BFBFBF" />
+                    <!--
+                        light barely needs the correction described in the dark section, the offset stays under
+                        one level above roughly 230
+                    -->
+                    <!--  Content Area -> #F2F2F2, opaque; the bottom bar paints its own color, see 6  -->
+                    <SolidColorBrush x:Key="FlyoutWindowBackground" Color="#F2F2F2" />
+                    <!--  Window Border -> literal #C0C0C0, reads as #BFBFBF here  -->
+                    <SolidColorBrush x:Key="FlyoutWindowBorderBrush" Color="#C0C0C0" />
 
-                    <!--  5. Flyout Graphs Content Background (Light Mode)  -->
-                    <!--  Graphs Content -> Target #F2F2F2 (242) over window base #EDEDED (237): Alpha 71 (0x47) White -> #47FFFFFF  -->
+                    <!--  5. Flyout Graphs Overlay (Light Mode)  -->
+                    <!--  only used in the blur modes, where it lifts the graphs area off the glass  -->
+                    <!--  (the opaque mode takes its content color from FlyoutWindowBackground and uses no overlay)  -->
                     <SolidColorBrush x:Key="FlyoutGraphsBackground" Color="#47FFFFFF" />
 
                     <!--  6. Flyout Bottom Bar (Light Mode)  -->
-                    <!--  Bottom Bar directly uses window base #EDEDED  -->
-                    <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="Transparent" />
+                    <!--  Bottom Bar -> Target #EDEDED (237), opaque and independent of the content area  -->
+                    <SolidColorBrush x:Key="FlyoutBottomBarBackground" Color="#EDEDED" />
+
+                    <!--  7. Flyout Bottom Bar Separator (Light Mode)  -->
+                    <!--  1px stroke between content area and bottom bar, solid in every backdrop mode  -->
+                    <!--  literal #DEDEDE, reads as #DDDDDD here  -->
+                    <SolidColorBrush x:Key="FlyoutBottomBarSeparatorBrush" Color="#DEDEDE" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>

--- a/FluentSensors/App.xaml.cs
+++ b/FluentSensors/App.xaml.cs
@@ -21,6 +21,11 @@ namespace FluentSensors
         public App()
         {
             InitializeComponent();
+
+            // settings are written through a 1s debounce, and MainWindow only flushes on its own two exit routes;
+            // an unhandled exception would drop whatever is still pending, so flush here as well
+            // a debugger stop or an external kill still cannot be covered, nothing managed runs on TerminateProcess
+            this.UnhandledException += (s, e) => PersistenceService.Instance.FlushAll();
         }
 
         /// <summary>

--- a/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
@@ -55,8 +55,10 @@ namespace FluentSensors.Controls.SensorGraph
             if (Scope == SensorGraphScope.Taskbar)
             {
                 GraphColor = ResolveGraphColor(SettingsService.Instance.TaskbarUseGraphAccentColor, SettingsService.Instance.TaskbarGraphCustomColor);
+                _isCardBackgroundVisible = !SettingsService.Instance.TaskbarUseTransparentGraphBackground;
                 SettingsService.Instance.TaskbarGraphColorChanged += OnGraphColorChanged;
                 SettingsService.Instance.TaskbarGraphTimeSpanChanged += OnGraphTimeSpanChanged;
+                SettingsService.Instance.TaskbarGraphBackgroundChanged += OnGraphBackgroundChanged;
             }
             else
             {
@@ -116,6 +118,21 @@ namespace FluentSensors.Controls.SensorGraph
         {
             get => _graphColor;
             private set { _graphColor = value; OnPropertyChanged(); }
+        }
+
+        // taskbar widget graphs can drop their calculated card tint and go fully transparent
+        // only the widget template binds this; the flyout renders these same instances with its own defaults,
+        // so it keeps its themed card background either way
+        private bool _isCardBackgroundVisible = true;
+        public bool IsCardBackgroundVisible
+        {
+            get => _isCardBackgroundVisible;
+            private set
+            {
+                if (_isCardBackgroundVisible == value) return;
+                _isCardBackgroundVisible = value;
+                OnPropertyChanged();
+            }
         }
 
         // threshold: owned by the shared editor, exposed so views can bind e.g. Threshold.Value, Threshold.IsEnabled
@@ -223,6 +240,11 @@ namespace FluentSensors.Controls.SensorGraph
             GraphColor = ResolveGraphColor(useAccent, customColor);
         }
 
+        private void OnGraphBackgroundChanged(bool useTransparentBackground)
+        {
+            IsCardBackgroundVisible = !useTransparentBackground;
+        }
+
         private void OnGraphTimeSpanChanged(double newTimeSpanSeconds)
         {
             // instances with a fixed override never resize with the global setting
@@ -258,6 +280,7 @@ namespace FluentSensors.Controls.SensorGraph
             {
                 SettingsService.Instance.TaskbarGraphColorChanged -= OnGraphColorChanged;
                 SettingsService.Instance.TaskbarGraphTimeSpanChanged -= OnGraphTimeSpanChanged;
+                SettingsService.Instance.TaskbarGraphBackgroundChanged -= OnGraphBackgroundChanged;
             }
             else
             {

--- a/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
@@ -43,10 +43,7 @@ namespace FluentSensors.Controls.SensorGraph
 
             // when set, this instance owns a fixed time span independent of the scope GraphTimeSpanSeconds setting
             _timeSpanOverrideSeconds = graphTimeSpanSecondsOverride;
-            double initialTimeSpanSeconds = graphTimeSpanSecondsOverride ?? (Scope == SensorGraphScope.Taskbar
-                ? SettingsService.Instance.TaskbarGraphTimeSpanSeconds
-                : SettingsService.Instance.GraphTimeSpanSeconds);
-            int initialPointCount = CalculatePointCount(initialTimeSpanSeconds, HardwareMonitorService.Instance.UpdateIntervalMs);
+            int initialPointCount = CalculatePointCount(ResolveTimeSpanSeconds(), HardwareMonitorService.Instance.UpdateIntervalMs);
 
             // this raw data list will be plotted by LiveCharts
             // we use LINQ Enumerable.Repeat to fill the entire list with "0.0" values at startup
@@ -395,9 +392,21 @@ namespace FluentSensors.Controls.SensorGraph
         // the current polling interval, and resizes to it
         private void RecalculatePointCount()
         {
-            double effectiveSeconds = _timeSpanOverrideSeconds ?? SettingsService.Instance.GraphTimeSpanSeconds;
-            int newCount = CalculatePointCount(effectiveSeconds, HardwareMonitorService.Instance.UpdateIntervalMs);
+            int newCount = CalculatePointCount(ResolveTimeSpanSeconds(), HardwareMonitorService.Instance.UpdateIntervalMs);
             ResizeSensorData(newCount);
+        }
+
+        // the time span this instance currently plots: its own fixed override if it has one, otherwise the setting
+        // belonging to its scope
+        // shared by the constructor and every later resize on purpose; resolving it separately in the two places is
+        // what let taskbar graphs get rebuilt against the widget windows range instead of their own
+        private double ResolveTimeSpanSeconds()
+        {
+            if (_timeSpanOverrideSeconds.HasValue) return _timeSpanOverrideSeconds.Value;
+
+            return Scope == SensorGraphScope.Taskbar
+                ? SettingsService.Instance.TaskbarGraphTimeSpanSeconds
+                : SettingsService.Instance.GraphTimeSpanSeconds;
         }
 
         // how many points a graph needs to cover timeSpanSeconds at the given polling interval

--- a/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
@@ -240,6 +240,16 @@ namespace FluentSensors.Controls.SensorGraph
 
         // === public methods ===
 
+        // re-resolves the graph color against the current settings and the live SystemAccentColor
+        // the constructor resolves it once, and SettingsService only reports the users own accent/custom switch;
+        // a Windows accent change reaches this instance through nothing else
+        public void RefreshGraphColor()
+        {
+            GraphColor = Scope == SensorGraphScope.Taskbar
+                ? ResolveGraphColor(SettingsService.Instance.TaskbarUseGraphAccentColor, SettingsService.Instance.TaskbarGraphCustomColor)
+                : ResolveGraphColor(SettingsService.Instance.UseGraphAccentColor, SettingsService.Instance.GraphCustomColor);
+        }
+
         // unsubscribes from SettingsService events and the threshold editor; without this, disposed sensor rows would
         // still react to graph color / data point / threshold changes after being removed
         public void Cleanup()

--- a/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Linq;
 
 using FluentSensors.Common.UI;
+using FluentSensors.Persistence.Services;
 
 
 namespace FluentSensors.Controls.SensorGraph
@@ -28,12 +29,20 @@ namespace FluentSensors.Controls.SensorGraph
         // plain text in that case
         private const bool ShowSwitchUiForSingleCandidate = true;
 
+        // graph-color card background alpha (UseGraphColorCardBackground)
+        private const byte GraphColorCardBackgroundAlphaDark = 44;
+        private const byte GraphColorCardBackgroundAlphaLight = 44; 
+
 
         // === constructor ===
 
         public SensorPanelControl()
         {
             InitializeComponent();
+
+            // the graph-color card background alpha depends on the theme (see GetEffectiveCardBackground), and the
+            // CardBackgroundOverride x:Bind does not otherwise re-run on a theme switch
+            ActualThemeChanged += (s, e) => Bindings.Update();
         }
 
 
@@ -584,7 +593,7 @@ namespace FluentSensors.Controls.SensorGraph
 
         // translates the panels ShowGraphCardBackground and UseGraphColorCardBackground into SensorGraphControl.CardBackgroundOverride:
         // showBackground = false -> explicit transparent override
-        // useGraphColor = true   -> 10% opacity tint of effective graph color
+        // useGraphColor = true   -> theme-dependent alpha tint of effective graph color
         // default                -> null (standard themed card background)
         private Windows.UI.Color? GetEffectiveCardBackground(bool showBackground, bool useGraphColor, Windows.UI.Color overrideColor, Windows.UI.Color autoColor)
         {
@@ -596,11 +605,23 @@ namespace FluentSensors.Controls.SensorGraph
             if (useGraphColor)
             {
                 Windows.UI.Color effectiveGraphColor = GetEffectiveGraphColor(overrideColor, autoColor);
-                // 10% opacity (alpha 25 / 255 ≈ 10%)
-                return Windows.UI.Color.FromArgb(30, effectiveGraphColor.R, effectiveGraphColor.G, effectiveGraphColor.B);
+                byte alpha = IsDarkTheme() ? GraphColorCardBackgroundAlphaDark : GraphColorCardBackgroundAlphaLight;
+                return Windows.UI.Color.FromArgb(alpha, effectiveGraphColor.R, effectiveGraphColor.G, effectiveGraphColor.B);
             }
 
             return null;
+        }
+
+        // same resolution order as DefaultTextColor.Resolve; a code-behind theme-resource lookup would ignore the apps
+        // RequestedTheme override, so the app theme setting is read directly with the OS theme as the fallback
+        private static bool IsDarkTheme()
+        {
+            return SettingsService.Instance.AppTheme switch
+            {
+                "Light" => false,
+                "Dark" => true,
+                _ => Application.Current.RequestedTheme == ApplicationTheme.Dark
+            };
         }
 
         private Windows.UI.Color? BoolToCardBorderOverride(bool showBorder) =>

--- a/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml.cs
@@ -360,7 +360,14 @@ namespace FluentSensors.Controls.SensorGraph
                 nameof(ShowGraphCardBackground),
                 typeof(bool),
                 typeof(SensorPanelControl),
-                new PropertyMetadata(true));
+                new PropertyMetadata(true, OnCardBackgroundVisibilityChanged));
+
+        // the CardBackgroundOverride x:Bind takes this as an argument, and nothing re-runs it when the property
+        // changes after load; same reason as the ActualThemeChanged refresh in the constructor
+        private static void OnCardBackgroundVisibilityChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SensorPanelControl panel) panel.Bindings.Update();
+        }
 
         // pure visual pass-through to SensorGraphControl.CardBorderOverride (true = standard theme border, false = transparent)
         public bool ShowGraphCardBorder

--- a/FluentSensors/Controls/VerticalStretchPanel.cs
+++ b/FluentSensors/Controls/VerticalStretchPanel.cs
@@ -30,6 +30,30 @@ namespace FluentSensors.Controls
             }
         }
 
+        // fixed height per child in DIP; 0 keeps the equal split
+        // a ScrollViewer measures its content with infinite height, where an equal split has nothing to divide, so a
+        // scrolling host hands the panel the row height to stack at instead
+        public double FixedItemHeight
+        {
+            get => (double)GetValue(FixedItemHeightProperty);
+            set => SetValue(FixedItemHeightProperty, value);
+        }
+
+        public static readonly DependencyProperty FixedItemHeightProperty =
+            DependencyProperty.Register(
+                nameof(FixedItemHeight),
+                typeof(double),
+                typeof(VerticalStretchPanel),
+                new PropertyMetadata(0.0, OnFixedItemHeightChanged));
+
+        private static void OnFixedItemHeightChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is VerticalStretchPanel panel)
+            {
+                panel.InvalidateMeasure();
+            }
+        }
+
         protected override Size MeasureOverride(Size availableSize)
         {
             int count = Children.Count;
@@ -42,14 +66,20 @@ namespace FluentSensors.Controls
             double measureHeight = double.IsInfinity(availableSize.Height) ? 0 : availableSize.Height;
 
             double totalSpacing = Spacing * (count - 1);
-            double cellHeight = Math.Max(0, (measureHeight - totalSpacing) / count);
+            double cellHeight = FixedItemHeight > 0
+                ? FixedItemHeight
+                : Math.Max(0, (measureHeight - totalSpacing) / count);
 
             foreach (var child in Children)
             {
                 child.Measure(new Size(measureWidth, cellHeight));
             }
 
-            return new Size(measureWidth, measureHeight);
+            // a fixed row height is the one case with a real content height to report, and reporting it is what lets
+            // a scrolling host know there is something to scroll
+            return FixedItemHeight > 0
+                ? new Size(measureWidth, (count * cellHeight) + totalSpacing)
+                : new Size(measureWidth, measureHeight);
         }
 
         protected override Size ArrangeOverride(Size finalSize)
@@ -58,7 +88,9 @@ namespace FluentSensors.Controls
             if (count == 0) return finalSize;
 
             double totalSpacing = Spacing * (count - 1);
-            double cellHeight = Math.Max(0, (finalSize.Height - totalSpacing) / count);
+            double cellHeight = FixedItemHeight > 0
+                ? FixedItemHeight
+                : Math.Max(0, (finalSize.Height - totalSpacing) / count);
 
             double y = 0;
             foreach (var child in Children)

--- a/FluentSensors/Features/Sensors/SensorsPage.xaml.cs
+++ b/FluentSensors/Features/Sensors/SensorsPage.xaml.cs
@@ -142,6 +142,24 @@ namespace FluentSensors.Features.Sensors
             RebuildCommandBarOverflow();
         }
 
+        // entry point for callers outside the page (currently the taskbar flyout) that want the list to open on a
+        // specific profile; drives the ComboBox rather than ViewModel.ActiveProfile so the handler above stays the
+        // single place that pairs the profile switch with the command bar rebuild
+        public void SelectProfile(SensorSelectionProfile profile)
+        {
+            foreach (var item in SelectionProfileComboBox.Items.OfType<ComboBoxItem>())
+            {
+                if (item.Tag is string tag
+                    && Enum.TryParse(tag, out SensorSelectionProfile itemProfile)
+                    && itemProfile == profile)
+                {
+                    // no-op if it is already the selected one, SelectionChanged simply does not fire
+                    SelectionProfileComboBox.SelectedItem = item;
+                    return;
+                }
+            }
+        }
+
         private void ResetMinMax_Click(object sender, RoutedEventArgs e)
         {
             // we iterate through all nested groups and all sensors

--- a/FluentSensors/Features/Settings/SettingsPage.xaml
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml
@@ -181,6 +181,33 @@
                 Style="{StaticResource BodyStrongTextBlockStyle}"
                 Text="Taskbar Widget &amp; Flyout Appearance" />
 
+            <!--  flyout alignment over the widget  -->
+            <controls:SettingsCard
+                Description="Where the flyout lines up relative to the widget"
+                Header="Flyout Alignment"
+                HeaderIcon="{toolkit:FontIcon Glyph=&#xE8E3;}">
+                <ComboBox
+                    x:Name="TaskbarFlyoutAlignmentComboBox"
+                    Width="160"
+                    SelectionChanged="TaskbarFlyoutAlignmentComboBox_SelectionChanged">
+                    <ComboBoxItem Content="Centered" Tag="Center" />
+                    <ComboBoxItem Content="Left" Tag="Left" />
+                    <ComboBoxItem Content="Right" Tag="Right" />
+                </ComboBox>
+            </controls:SettingsCard>
+
+            <!--  drag lock for the widget position on the taskbar  -->
+            <controls:SettingsCard
+                Description="Stop the widget from being dragged along the taskbar"
+                Header="Lock Widget Position"
+                HeaderIcon="{toolkit:FontIcon Glyph=&#xE72E;}">
+                <ToggleSwitch
+                    x:Name="LockWidgetPositionToggle"
+                    OffContent="Off"
+                    OnContent="On"
+                    Toggled="LockWidgetPositionToggle_Toggled" />
+            </controls:SettingsCard>
+
             <!--  taskbar background material  -->
             <controls:SettingsExpander
                 Description="Backdrop effect and color for the taskbar flyout"

--- a/FluentSensors/Features/Settings/SettingsPage.xaml
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml
@@ -181,6 +181,79 @@
                 Style="{StaticResource BodyStrongTextBlockStyle}"
                 Text="Taskbar Widget &amp; Flyout Appearance" />
 
+            <!--  drag lock for the widget position on the taskbar  -->
+            <controls:SettingsCard
+                Description="Stop the taskbar widget from being dragged along the taskbar"
+                Header="Lock Taskbar Widget Position"
+                HeaderIcon="{toolkit:FontIcon Glyph=&#xE72E;}">
+                <ToggleSwitch
+                    x:Name="LockWidgetPositionToggle"
+                    OffContent="Off"
+                    OnContent="On"
+                    Toggled="LockWidgetPositionToggle_Toggled" />
+            </controls:SettingsCard>
+
+            <!--  taskbar graph appearance  -->
+            <controls:SettingsExpander
+                Description="Taskbar graph color, background, time range and graph Width"
+                Header="Graph"
+                HeaderIcon="{toolkit:FontIcon Glyph=&#xE9D2;}"
+                IsExpanded="False">
+
+                <controls:SettingsExpander.Items>
+                    <controls:SettingsCard Header="Graph Color Source">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <ComboBox
+                                x:Name="TaskbarGraphColorSourceComboBox"
+                                Width="160"
+                                SelectionChanged="TaskbarGraphColorSourceComboBox_SelectionChanged">
+                                <ComboBoxItem Content="Windows Accent" Tag="Accent" />
+                                <ComboBoxItem Content="Custom Color" Tag="Custom" />
+                            </ComboBox>
+
+                            <controls:ColorPickerButton x:Name="TaskbarGraphColorPicker" />
+                        </StackPanel>
+                    </controls:SettingsCard>
+
+                    <!--  transparent drops the calculated tint so the taskbar shows through the graph cards  -->
+                    <controls:SettingsCard Header="Graph Background Source">
+                        <ComboBox
+                            x:Name="TaskbarGraphBackgroundSourceComboBox"
+                            Width="160"
+                            SelectionChanged="TaskbarGraphBackgroundSourceComboBox_SelectionChanged">
+                            <ComboBoxItem Content="Calculated" Tag="Calculated" />
+                            <ComboBoxItem Content="Transparent" Tag="Transparent" />
+                        </ComboBox>
+                    </controls:SettingsCard>
+
+                    <controls:SettingsCard Header="Time Range">
+                        <ComboBox
+                            x:Name="TaskbarGraphTimeSpanComboBox"
+                            Width="40"
+                            SelectionChanged="TaskbarGraphTimeSpanComboBox_SelectionChanged">
+                            <ComboBoxItem Content="15s" Tag="15" />
+                            <ComboBoxItem Content="20s" Tag="20" />
+                            <ComboBoxItem Content="30s" Tag="30" />
+                            <ComboBoxItem Content="45s" Tag="45" />
+                            <ComboBoxItem Content="60s" Tag="60" />
+                            <ComboBoxItem Content="90s" Tag="90" />
+                            <ComboBoxItem Content="120s" Tag="120" />
+                            <ComboBoxItem Content="240s" Tag="240" />
+                        </ComboBox>
+                    </controls:SettingsCard>
+                    <controls:SettingsCard Header="Graph Width">
+                        <Slider
+                            x:Name="TaskbarGraphWidthSlider"
+                            Width="200"
+                            Maximum="240"
+                            Minimum="60"
+                            StepFrequency="5"
+                            TickFrequency="20"
+                            ValueChanged="TaskbarGraphWidthSlider_ValueChanged" />
+                    </controls:SettingsCard>
+                </controls:SettingsExpander.Items>
+            </controls:SettingsExpander>
+
             <!--  flyout alignment over the widget  -->
             <controls:SettingsCard
                 Description="Where the flyout lines up relative to the widget"
@@ -196,22 +269,10 @@
                 </ComboBox>
             </controls:SettingsCard>
 
-            <!--  drag lock for the widget position on the taskbar  -->
-            <controls:SettingsCard
-                Description="Stop the widget from being dragged along the taskbar"
-                Header="Lock Widget Position"
-                HeaderIcon="{toolkit:FontIcon Glyph=&#xE72E;}">
-                <ToggleSwitch
-                    x:Name="LockWidgetPositionToggle"
-                    OffContent="Off"
-                    OnContent="On"
-                    Toggled="LockWidgetPositionToggle_Toggled" />
-            </controls:SettingsCard>
-
-            <!--  taskbar background material  -->
+            <!--  flyout background material  -->
             <controls:SettingsExpander
                 Description="Backdrop effect and color for the taskbar flyout"
-                Header="Background Material"
+                Header="Flyout Background Material"
                 HeaderIcon="{toolkit:FontIcon Glyph=&#xEF1F;}"
                 IsExpanded="False">
 
@@ -259,56 +320,6 @@
 
                             <controls:ColorPickerButton x:Name="TaskbarBackgroundColorPicker" />
                         </StackPanel>
-                    </controls:SettingsCard>
-                </controls:SettingsExpander.Items>
-            </controls:SettingsExpander>
-
-            <!--  taskbar graph appearance  -->
-            <controls:SettingsExpander
-                Description="Taskbar graph color, time range and graph Width"
-                Header="Graph"
-                HeaderIcon="{toolkit:FontIcon Glyph=&#xE9D2;}"
-                IsExpanded="False">
-
-                <controls:SettingsExpander.Items>
-                    <controls:SettingsCard Header="Graph Color Source">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <ComboBox
-                                x:Name="TaskbarGraphColorSourceComboBox"
-                                Width="160"
-                                SelectionChanged="TaskbarGraphColorSourceComboBox_SelectionChanged">
-                                <ComboBoxItem Content="Windows Accent" Tag="Accent" />
-                                <ComboBoxItem Content="Custom Color" Tag="Custom" />
-                            </ComboBox>
-
-                            <controls:ColorPickerButton x:Name="TaskbarGraphColorPicker" />
-                        </StackPanel>
-                    </controls:SettingsCard>
-
-                    <controls:SettingsCard Header="Time Range">
-                        <ComboBox
-                            x:Name="TaskbarGraphTimeSpanComboBox"
-                            Width="40"
-                            SelectionChanged="TaskbarGraphTimeSpanComboBox_SelectionChanged">
-                            <ComboBoxItem Content="15s" Tag="15" />
-                            <ComboBoxItem Content="20s" Tag="20" />
-                            <ComboBoxItem Content="30s" Tag="30" />
-                            <ComboBoxItem Content="45s" Tag="45" />
-                            <ComboBoxItem Content="60s" Tag="60" />
-                            <ComboBoxItem Content="90s" Tag="90" />
-                            <ComboBoxItem Content="120s" Tag="120" />
-                            <ComboBoxItem Content="240s" Tag="240" />
-                        </ComboBox>
-                    </controls:SettingsCard>
-                    <controls:SettingsCard Header="Graph Width">
-                        <Slider
-                            x:Name="TaskbarGraphWidthSlider"
-                            Width="200"
-                            Maximum="240"
-                            Minimum="60"
-                            StepFrequency="5"
-                            TickFrequency="20"
-                            ValueChanged="TaskbarGraphWidthSlider_ValueChanged" />
                     </controls:SettingsCard>
                 </controls:SettingsExpander.Items>
             </controls:SettingsExpander>

--- a/FluentSensors/Features/Settings/SettingsPage.xaml.cs
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml.cs
@@ -38,6 +38,7 @@ namespace FluentSensors.Features.Settings
 
             RestoreTaskbarBackgroundMaterialSettings();
             RestoreTaskbarGraphColorSettings();
+            RestoreTaskbarGraphBackgroundSourceSelection();
             RestoreTaskbarGraphTimeSpanSelection();
             RestoreTaskbarGraphWidthSelection();
             RestoreTaskbarFlyoutAlignmentSelection();
@@ -354,6 +355,14 @@ namespace FluentSensors.Features.Settings
             }
         }
 
+        private void TaskbarGraphBackgroundSourceComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (TaskbarGraphBackgroundSourceComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                SettingsService.Instance.TaskbarUseTransparentGraphBackground = (tag == "Transparent");
+            }
+        }
+
         private void TaskbarGraphTimeSpanComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (_isLoading) return;
@@ -371,6 +380,12 @@ namespace FluentSensors.Features.Settings
         {
             TaskbarGraphColorSourceComboBox.SelectedIndex = SettingsService.Instance.TaskbarUseGraphAccentColor ? 0 : 1;
             TaskbarGraphColorPicker.SelectedColor = SettingsService.Instance.TaskbarGraphCustomColor;
+        }
+
+        private void RestoreTaskbarGraphBackgroundSourceSelection()
+        {
+            TaskbarGraphBackgroundSourceComboBox.SelectedIndex =
+                SettingsService.Instance.TaskbarUseTransparentGraphBackground ? 1 : 0;
         }
 
         private void RestoreTaskbarGraphTimeSpanSelection()

--- a/FluentSensors/Features/Settings/SettingsPage.xaml.cs
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml.cs
@@ -40,6 +40,8 @@ namespace FluentSensors.Features.Settings
             RestoreTaskbarGraphColorSettings();
             RestoreTaskbarGraphTimeSpanSelection();
             RestoreTaskbarGraphWidthSelection();
+            RestoreTaskbarFlyoutAlignmentSelection();
+            RestoreLockWidgetPositionSelection();
 
 
             // event listeners
@@ -394,6 +396,43 @@ namespace FluentSensors.Features.Settings
         private void RestoreTaskbarGraphWidthSelection()
         {
             TaskbarGraphWidthSlider.Value = SettingsService.Instance.TaskbarGraphWidthDip;
+        }
+
+        // flyout alignment over the widget
+        private void TaskbarFlyoutAlignmentComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+
+            if (TaskbarFlyoutAlignmentComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tag)
+            {
+                SettingsService.Instance.TaskbarFlyoutAlignment = tag;
+            }
+        }
+
+        private void RestoreTaskbarFlyoutAlignmentSelection()
+        {
+            string currentAlignment = SettingsService.Instance.TaskbarFlyoutAlignment;
+
+            foreach (ComboBoxItem item in TaskbarFlyoutAlignmentComboBox.Items)
+            {
+                if (item.Tag?.ToString() == currentAlignment)
+                {
+                    TaskbarFlyoutAlignmentComboBox.SelectedItem = item;
+                    break;
+                }
+            }
+        }
+
+        // widget drag lock
+        private void LockWidgetPositionToggle_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
+            SettingsService.Instance.TaskbarWidgetPositionLocked = LockWidgetPositionToggle.IsOn;
+        }
+
+        private void RestoreLockWidgetPositionSelection()
+        {
+            LockWidgetPositionToggle.IsOn = SettingsService.Instance.TaskbarWidgetPositionLocked;
         }
 
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -100,8 +100,8 @@
                         <Thickness x:Key="AppBarButtonPadding">0,0,0,0</Thickness>
                     </Grid.Resources>
 
-                    <!--  open main app window  -->
-                    <!--  (icon and label)  -->
+                    <!--  open the sensor list on the taskbar profile  -->
+                    <!--  (label only)  -->
                     <CommandBar
                         HorizontalAlignment="Left"
                         Background="Transparent"
@@ -114,14 +114,18 @@
                                 x:Name="BackToDashboardButton"
                                 Click="BackToDashboard_Click"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Label="Open App"
-                                ToolTipService.ToolTip="Open the main app window">
-                                <AppBarButton.Icon>
-                                    <FontIcon
-                                        FontSize="14"
-                                        FontWeight="SemiLight"
-                                        Glyph="&#xE944;" />
-                                </AppBarButton.Icon>
+                                Label="Manage Taskbar Sensors">
+
+                                <!--  runs without an icon; the glyph column is sized by the LabelOnRight visual state  -->
+                                <!--
+                                    the label margin itself is unreachable: the LabelOnRight state assigns it from a
+                                    StaticResource, which resolves once inside the platform dictionary and never looks
+                                    at this scope, so its fixed 8,16,12,10 always wins
+                                -->
+                                <AppBarButton.Resources>
+                                    <x:Double x:Key="AppBarButtonContentHeight">0</x:Double>
+                                    <Thickness x:Key="AppBarButtonContentViewboxMargin">5,0,0,0</Thickness>
+                                </AppBarButton.Resources>
                             </AppBarButton>
                         </CommandBar.PrimaryCommands>
                     </CommandBar>

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -79,6 +79,26 @@
             </Grid.RowDefinitions>
 
 
+            <!--  acrylic grain  -->
+            <!--
+                the material composites a noise layer as its last step, the system backdrop controller does not,
+                so this paints the missing one; it stays below every surface fill, so it grains the material and
+                never the text or the graphs on top of it
+            -->
+            <!--
+                the canvas keeps the layer out of the layout: the rectangle is sized in physical pixels and
+                scaled back down from code, which would otherwise stretch the rows
+            -->
+            <Canvas
+                x:Name="FlyoutNoiseHost"
+                Grid.Row="0"
+                Grid.RowSpan="2"
+                IsHitTestVisible="False"
+                Visibility="Collapsed">
+                <Rectangle x:Name="FlyoutNoiseOverlay" />
+            </Canvas>
+
+
             <!--  vertical list of sensor graphs  -->
             <Grid
                 x:Name="GraphsContentGrid"

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -18,60 +18,6 @@
         BorderThickness="1"
         CornerRadius="8">
 
-        <Border.Resources>
-
-            <!--  bottom bar action button: flat and transparent at rest, subtle fill on hover and press  -->
-            <Style x:Key="FlyoutBottomBarButtonStyle" TargetType="Button">
-                <Setter Property="Background" Value="Transparent" />
-                <Setter Property="BorderThickness" Value="0" />
-                <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}" />
-                <Setter Property="Padding" Value="10,5" />
-                <Setter Property="CornerRadius" Value="4" />
-                <Setter Property="HorizontalContentAlignment" Value="Center" />
-                <Setter Property="VerticalContentAlignment" Value="Center" />
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="Button">
-                            <Border
-                                x:Name="RootBorder"
-                                Background="{TemplateBinding Background}"
-                                CornerRadius="{TemplateBinding CornerRadius}">
-                                <ContentPresenter
-                                    x:Name="ContentPresenter"
-                                    Padding="{TemplateBinding Padding}"
-                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                    Content="{TemplateBinding Content}"
-                                    ContentTemplate="{TemplateBinding ContentTemplate}"
-                                    Foreground="{TemplateBinding Foreground}" />
-
-                                <VisualStateManager.VisualStateGroups>
-                                    <VisualStateGroup x:Name="CommonStates">
-                                        <VisualState x:Name="Normal" />
-                                        <VisualState x:Name="PointerOver">
-                                            <VisualState.Setters>
-                                                <Setter Target="RootBorder.Background" Value="{ThemeResource ControlFillColorSecondaryBrush}" />
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="Pressed">
-                                            <VisualState.Setters>
-                                                <Setter Target="RootBorder.Background" Value="{ThemeResource ControlFillColorTertiaryBrush}" />
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="Disabled">
-                                            <VisualState.Setters>
-                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                    </VisualStateGroup>
-                                </VisualStateManager.VisualStateGroups>
-                            </Border>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-        </Border.Resources>
-
         <Grid x:Name="RootGrid" Background="Transparent">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
@@ -103,13 +49,12 @@
             <Grid
                 x:Name="GraphsContentGrid"
                 Grid.Row="0"
-                Padding="6,1,6,6"
                 Background="{ThemeResource FlyoutGraphsBackground}"
                 CornerRadius="7,7,0,0">
-                <ItemsControl ItemsSource="{x:Bind ViewModel.PinnedSensors, Mode=OneWay}">
+                <ItemsControl x:Name="GraphsItemsControl" ItemsSource="{x:Bind ViewModel.PinnedSensors, Mode=OneWay}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <fhControls:VerticalStretchPanel Spacing="8" />
+                            <fhControls:VerticalStretchPanel />
                         </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
 
@@ -135,34 +80,67 @@
                 BorderThickness="0,1,0,0"
                 CornerRadius="0,0,7,7">
 
-                <Grid>
+                <Grid x:Name="BottomBarContentGrid">
+                    <Grid.Resources>
+                        <SolidColorBrush x:Key="CommandBarBackground" Color="Transparent" />
+                        <SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
+                        <SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
 
-                    <!--  back to main window (icon and label)  -->
-                    <Button
+                        <Thickness x:Key="AppBarButtonPadding">0,0,0,0</Thickness>
+                    </Grid.Resources>
+
+                    <!--  back to main window  -->
+                    <!--  (icon and label)  -->
+                    <CommandBar
                         HorizontalAlignment="Left"
-                        Click="BackToDashboard_Click"
-                        Style="{StaticResource FlyoutBottomBarButtonStyle}"
-                        ToolTipService.ToolTip="Back to Main Window">
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <FontIcon
-                                FontSize="14"
-                                FontWeight="SemiLight"
-                                Glyph="&#xE944;" />
-                            <TextBlock Text="Back to Main Window" />
-                        </StackPanel>
-                    </Button>
+                        Background="Transparent"
+                        DefaultLabelPosition="Right"
+                        IsDynamicOverflowEnabled="False"
+                        IsOpen="False"
+                        OverflowButtonVisibility="Collapsed">
+                        <CommandBar.PrimaryCommands>
+                            <AppBarButton
+                                x:Name="BackToDashboardButton"
+                                Click="BackToDashboard_Click"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Label="Back to Main Window"
+                                ToolTipService.ToolTip="Back to Main Window">
+                                <AppBarButton.Icon>
+                                    <FontIcon
+                                        FontSize="14"
+                                        FontWeight="SemiLight"
+                                        Glyph="&#xE944;" />
+                                </AppBarButton.Icon>
+                            </AppBarButton>
+                        </CommandBar.PrimaryCommands>
+                    </CommandBar>
 
-                    <!--  close taskbar widget (icon only)  -->
-                    <Button
+                    <!--  close taskbar widget  -->
+                    <!--  (icon only)  -->
+                    <CommandBar
                         HorizontalAlignment="Right"
-                        Click="CloseWidget_Click"
-                        Style="{StaticResource FlyoutBottomBarButtonStyle}"
-                        ToolTipService.ToolTip="Close Taskbar Widget">
-                        <FontIcon
-                            FontSize="10"
-                            FontWeight="SemiLight"
-                            Glyph="&#xE8BB;" />
-                    </Button>
+                        Background="Transparent"
+                        DefaultLabelPosition="Collapsed"
+                        IsDynamicOverflowEnabled="False"
+                        IsOpen="False"
+                        OverflowButtonVisibility="Collapsed">
+                        <CommandBar.PrimaryCommands>
+                            <AppBarButton
+                                x:Name="CloseWidgetButton"
+                                Width="44"
+                                Click="CloseWidget_Click"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Label="Close Taskbar Widget"
+                                ToolTipService.ToolTip="Close Taskbar Widget">
+                                <AppBarButton.Icon>
+                                    <FontIcon
+                                        FontSize="10.5"
+                                        FontWeight="SemiLight"
+                                        Glyph="&#xE711;" />
+                                </AppBarButton.Icon>
+                            </AppBarButton>
+                        </CommandBar.PrimaryCommands>
+                    </CommandBar>
                 </Grid>
             </Border>
         </Grid>

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -108,9 +108,10 @@
 
             <!--  bottom bar: navigation actions  -->
             <Border
+                x:Name="FlyoutBottomBarBorder"
                 Grid.Row="1"
                 Background="{ThemeResource FlyoutBottomBarBackground}"
-                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderBrush="{ThemeResource FlyoutBottomBarSeparatorBrush}"
                 BorderThickness="0,1,0,0"
                 CornerRadius="0,0,7,7">
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -51,23 +51,34 @@
                 Grid.Row="0"
                 Background="{ThemeResource FlyoutGraphsBackground}"
                 CornerRadius="7,7,0,0">
-                <ItemsControl x:Name="GraphsItemsControl" ItemsSource="{x:Bind ViewModel.PinnedSensors, Mode=OneWay}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <fhControls:VerticalStretchPanel />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
 
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="fhGraph:SensorGraphViewModel">
-                            <fhGraph:SensorPanelControl
-                                ShowStatusRow="True"
-                                ShowThresholdControls="True"
-                                ShowYAxisControls="True"
-                                ViewModel="{x:Bind}" />
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
+                <!--  the graphs scroll only once the pinned sensor count pushes the window past its height cap  -->
+                <!--  (both modes are switched from code, see ApplyGraphsScrollMode)  -->
+                <ScrollViewer
+                    x:Name="GraphsScrollViewer"
+                    HorizontalScrollBarVisibility="Disabled"
+                    HorizontalScrollMode="Disabled"
+                    VerticalScrollBarVisibility="Disabled"
+                    VerticalScrollMode="Disabled"
+                    ZoomMode="Disabled">
+                    <ItemsControl x:Name="GraphsItemsControl" ItemsSource="{x:Bind ViewModel.PinnedSensors, Mode=OneWay}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <fhControls:VerticalStretchPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="fhGraph:SensorGraphViewModel">
+                                <fhGraph:SensorPanelControl
+                                    ShowStatusRow="True"
+                                    ShowThresholdControls="True"
+                                    ShowYAxisControls="True"
+                                    ViewModel="{x:Bind}" />
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
             </Grid>
 
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -17,60 +17,75 @@
         BorderBrush="{ThemeResource FlyoutWindowBorderBrush}"
         BorderThickness="1"
         CornerRadius="8">
+
+        <Border.Resources>
+
+            <!--  bottom bar action button: flat and transparent at rest, subtle fill on hover and press  -->
+            <Style x:Key="FlyoutBottomBarButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}" />
+                <Setter Property="Padding" Value="10,5" />
+                <Setter Property="CornerRadius" Value="4" />
+                <Setter Property="HorizontalContentAlignment" Value="Center" />
+                <Setter Property="VerticalContentAlignment" Value="Center" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border
+                                x:Name="RootBorder"
+                                Background="{TemplateBinding Background}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                                <ContentPresenter
+                                    x:Name="ContentPresenter"
+                                    Padding="{TemplateBinding Padding}"
+                                    HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                    VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                    Content="{TemplateBinding Content}"
+                                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                                    Foreground="{TemplateBinding Foreground}" />
+
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal" />
+                                        <VisualState x:Name="PointerOver">
+                                            <VisualState.Setters>
+                                                <Setter Target="RootBorder.Background" Value="{ThemeResource ControlFillColorSecondaryBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Pressed">
+                                            <VisualState.Setters>
+                                                <Setter Target="RootBorder.Background" Value="{ThemeResource ControlFillColorTertiaryBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Disabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </Border.Resources>
+
         <Grid x:Name="RootGrid" Background="Transparent">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-
-
-            <!--  custom header bar  -->
-            <Grid
-                x:Name="CustomTitleBar"
-                Grid.Row="0"
-                Height="auto"
-                Background="Transparent">
-
-                <Grid Margin="4,4,4,0" HorizontalAlignment="Stretch">
-
-                    <!--  back to main application button  -->
-                    <Button
-                        Width="32"
-                        Height="22"
-                        Padding="0"
-                        HorizontalAlignment="Left"
-                        Click="BackToDashboard_Click"
-                        Style="{StaticResource SubtleButtonStyle}"
-                        ToolTipService.ToolTip="Back to Main Application">
-                        <FontIcon
-                            FontSize="14"
-                            FontWeight="SemiLight"
-                            Glyph="&#xE944;" />
-                    </Button>
-
-                    <!--  close taskbar widget button  -->
-                    <Button
-                        Width="32"
-                        Height="22"
-                        Padding="0"
-                        HorizontalAlignment="Right"
-                        Click="CloseWidget_Click"
-                        Style="{StaticResource SubtleButtonStyle}"
-                        ToolTipService.ToolTip="Close Taskbar Widget">
-                        <FontIcon
-                            FontSize="10"
-                            FontWeight="SemiLight"
-                            Glyph="&#xE8BB;" />
-                    </Button>
-                </Grid>
-            </Grid>
 
 
             <!--  vertical list of sensor graphs  -->
             <Grid
                 x:Name="GraphsContentGrid"
-                Grid.Row="1"
-                Padding="6,1,6,6">
+                Grid.Row="0"
+                Padding="6,1,6,6"
+                Background="{ThemeResource FlyoutGraphsBackground}"
+                CornerRadius="7,7,0,0">
                 <ItemsControl ItemsSource="{x:Bind ViewModel.PinnedSensors, Mode=OneWay}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
@@ -89,6 +104,46 @@
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
             </Grid>
+
+
+            <!--  bottom bar: navigation actions  -->
+            <Border
+                Grid.Row="1"
+                Background="{ThemeResource FlyoutBottomBarBackground}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                BorderThickness="0,1,0,0"
+                CornerRadius="0,0,7,7">
+
+                <Grid>
+
+                    <!--  back to main window (icon and label)  -->
+                    <Button
+                        HorizontalAlignment="Left"
+                        Click="BackToDashboard_Click"
+                        Style="{StaticResource FlyoutBottomBarButtonStyle}"
+                        ToolTipService.ToolTip="Back to Main Window">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <FontIcon
+                                FontSize="14"
+                                FontWeight="SemiLight"
+                                Glyph="&#xE944;" />
+                            <TextBlock Text="Back to Main Window" />
+                        </StackPanel>
+                    </Button>
+
+                    <!--  close taskbar widget (icon only)  -->
+                    <Button
+                        HorizontalAlignment="Right"
+                        Click="CloseWidget_Click"
+                        Style="{StaticResource FlyoutBottomBarButtonStyle}"
+                        ToolTipService.ToolTip="Close Taskbar Widget">
+                        <FontIcon
+                            FontSize="10"
+                            FontWeight="SemiLight"
+                            Glyph="&#xE8BB;" />
+                    </Button>
+                </Grid>
+            </Border>
         </Grid>
     </Border>
 </Window>

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -89,7 +89,7 @@
                         <Thickness x:Key="AppBarButtonPadding">0,0,0,0</Thickness>
                     </Grid.Resources>
 
-                    <!--  back to main window  -->
+                    <!--  open main app window  -->
                     <!--  (icon and label)  -->
                     <CommandBar
                         HorizontalAlignment="Left"
@@ -103,8 +103,8 @@
                                 x:Name="BackToDashboardButton"
                                 Click="BackToDashboard_Click"
                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Label="Back to Main Window"
-                                ToolTipService.ToolTip="Back to Main Window">
+                                Label="Open App"
+                                ToolTipService.ToolTip="Open the main app window">
                                 <AppBarButton.Icon>
                                     <FontIcon
                                         FontSize="14"

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace FluentSensors.Features.TaskbarWidget
     // 1. eliminates the non-client titlebar stripe via WM_NCCALCSIZE (0x0083) returning 0
     // 2. caps its own height against the work area and scrolls the graph list rather than growing past it
     // 3. places the window directly beneath Shell_TrayWnd in Z-order so it slides out from under the taskbar
-    // 4. coordinates a physical window slide via DispatcherTimer with direct composition opacity fading
+    // 4. coordinates a physical window slide via CompositionTarget.Rendering with direct composition opacity fading
     // 5. applies dynamic DWM corner preferences and shadow suppression depending on the Windows transparency setting
     // 6. integrates DesktopAcrylicController / Mica system backdrop with a swapchain kick on theme changes
     //
@@ -149,7 +149,7 @@ namespace FluentSensors.Features.TaskbarWidget
         public const double MaxAnimationScaleFactor = 3.0;
 
         // fade opacity (1.0f = no fade, 0.0f = full fade)
-        public const float EnterFadeStartOpacity = 0.9f; // initial opacity when opening
+        public const float EnterFadeStartOpacity = 0.0f; // initial opacity when opening
         public const float EnterFadeEndOpacity = 1.0f; // target opacity when opening
         public const float ExitFadeEndOpacity = 0.9f; // target opacity when closing
 
@@ -247,11 +247,20 @@ namespace FluentSensors.Features.TaskbarWidget
         private FluentSensors.Controls.VerticalStretchPanel? _graphsPanel;
         private bool _isGraphsScrolling;
 
-        // native window animation timer
-        private DispatcherTimer? _animTimer;
+        // native window animation, ticked from CompositionTarget.Rendering rather than a DispatcherTimer:
+        // a DispatcherTimer cannot go below the ~15.6ms Windows scheduler granularity (~64 fps) regardless of the
+        // requested interval, while the compositor frame tick tracks the displays actual refresh rate
+        private bool _isAnimating;
         private Stopwatch? _animStopwatch;
         private int _animStartX, _animStartY, _animTargetX, _animTargetY;
+        private int _animDurationMs;
+        private bool _animIsEntering;
         private Action? _animOnComplete;
+
+        // both slides travel this many physical pixels; computed once per open in PositionAboveTaskbar from the
+        // taskbars own DPI, and read from here rather than recomputed against the window DPI at slide time, which
+        // could disagree with it on a mixed-DPI setup and jump the first frame
+        private int _slideDistancePx;
 
         public TaskbarWidgetViewModel ViewModel { get; }
         public static TaskbarFlyoutWindow? CurrentInstance { get; private set; }
@@ -355,6 +364,7 @@ namespace FluentSensors.Features.TaskbarWidget
             try
             {
                 _uiSettings = new UISettings();
+                SeedSystemVisualsSnapshot(_uiSettings);
                 _uiSettings.AdvancedEffectsEnabledChanged += OnSystemVisualSettingsChanged;
                 _uiSettings.ColorValuesChanged += OnSystemVisualSettingsChanged;
                 UpdateShadowPolicy();
@@ -367,9 +377,13 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // a named handler rather than a lambda, so SafeDestroy can detach it again; every rebuilt window subscribes
         // anew and without the detach the UISettings handler list grows by one per rebuild
+        //
+        // routes to RouteSystemVisualsChange rather than ScheduleRecreation directly: AdvancedEffectsEnabledChanged
+        // always means a rebuild (the DWM acrylic rebind, see ScheduleRecreation below), but ColorValuesChanged also
+        // fires for a pure accent change, which the router resolves into the cheap in-place refresh instead
         private void OnSystemVisualSettingsChanged(UISettings sender, object args)
         {
-            ScheduleRecreation();
+            RouteSystemVisualsChange(sender);
         }
 
         private void UpdateShadowPolicy()
@@ -566,6 +580,10 @@ namespace FluentSensors.Features.TaskbarWidget
             if (_isClosed) return;
             _isClosed = true;
 
+            // unhooks CompositionTarget.Rendering if a slide is still in flight; that event is static and keeps
+            // firing for the life of the process otherwise, ticking a handler on a window that no longer exists
+            StopSlide();
+
             try
             {
                 SettingsService.Instance.ThemeChanged -= OnThemeChanged;
@@ -610,6 +628,113 @@ namespace FluentSensors.Features.TaskbarWidget
         }
 
         private static Microsoft.UI.Dispatching.DispatcherQueueTimer? _recreateDebounceTimer;
+        private static Microsoft.UI.Dispatching.DispatcherQueueTimer? _accentRefreshDebounceTimer;
+
+        // last seen OS visual state; ColorValuesChanged fires for an accent change and for a light/dark switch
+        // alike, and the event carries no detail of what changed, so telling them apart means comparing snapshots
+        private static Windows.UI.Color _lastAccentColor;
+        private static Windows.UI.Color _lastBackgroundColor;
+        private static bool _lastAdvancedEffectsEnabled;
+        private static bool _hasVisualSnapshot;
+
+        // establishes the baseline before any UISettings event has fired, so the first real event diffs against
+        // the actual prior state instead of every field reading as changed and forcing a rebuild unconditionally
+        //
+        // both WidgetWindow and TaskbarFlyoutWindow own a UISettings instance and call this from their own
+        // constructor; harmless to call twice, it always just records the current true state
+        public static void SeedSystemVisualsSnapshot(UISettings settings)
+        {
+            _lastAccentColor = settings.GetColorValue(UIColorType.Accent);
+            _lastBackgroundColor = settings.GetColorValue(UIColorType.Background);
+            _lastAdvancedEffectsEnabled = settings.AdvancedEffectsEnabled;
+            _hasVisualSnapshot = true;
+        }
+
+        // routes a Windows-level visual settings change to the cheap in-place accent refresh or the expensive
+        // full rebuild, depending on what actually changed
+        //
+        // WidgetWindow and TaskbarFlyoutWindow each own a UISettings instance and both land here for the same OS
+        // event, so a single accent change calls this twice; the second call sees no further difference and does
+        // nothing, which is also what dedupes a picker being dragged through several colors in quick succession
+        public static void RouteSystemVisualsChange(UISettings sender)
+        {
+            var accent = sender.GetColorValue(UIColorType.Accent);
+            var background = sender.GetColorValue(UIColorType.Background);
+            bool advancedEffects = sender.AdvancedEffectsEnabled;
+
+            if (!_hasVisualSnapshot)
+            {
+                SeedSystemVisualsSnapshot(sender);
+                ScheduleRecreation();
+                return;
+            }
+
+            bool accentChanged = !accent.Equals(_lastAccentColor);
+            bool structuralChanged = !background.Equals(_lastBackgroundColor) || advancedEffects != _lastAdvancedEffectsEnabled;
+
+            _lastAccentColor = accent;
+            _lastBackgroundColor = background;
+            _lastAdvancedEffectsEnabled = advancedEffects;
+
+            if (structuralChanged)
+            {
+                ScheduleRecreation();
+            }
+            else if (accentChanged)
+            {
+                ScheduleAccentRefresh();
+            }
+        }
+
+        // debounced entry point for a pure accent color change: refreshes every accent-driven surface in place,
+        // no window is torn down; the 150ms debounce matches ScheduleRecreation, Windows can raise
+        // ColorValuesChanged repeatedly while a color is being dragged through a picker
+        private static void ScheduleAccentRefresh()
+        {
+            var queue = TaskbarWidgetWindow.CurrentInstance?.DispatcherQueue
+                ?? MainWindow.CurrentInstance?.DispatcherQueue
+                ?? DispatcherQueue.GetForCurrentThread();
+
+            if (queue == null) return;
+
+            queue.TryEnqueue(() =>
+            {
+                if (_accentRefreshDebounceTimer != null)
+                {
+                    _accentRefreshDebounceTimer.Stop();
+                    _accentRefreshDebounceTimer = null;
+                }
+
+                _accentRefreshDebounceTimer = queue.CreateTimer();
+                _accentRefreshDebounceTimer.Interval = TimeSpan.FromMilliseconds(150);
+                _accentRefreshDebounceTimer.IsRepeating = false;
+                _accentRefreshDebounceTimer.Tick += (s, e) =>
+                {
+                    _accentRefreshDebounceTimer?.Stop();
+                    _accentRefreshDebounceTimer = null;
+                    ExecuteAccentRefresh();
+                };
+                _accentRefreshDebounceTimer.Start();
+            });
+        }
+
+        // refreshes every accent-driven surface across all three windows in place: pinned graph colors, and for
+        // the taskbar widget the card tint that rides on the same GraphColor, plus the acrylic tint and solid
+        // background on WidgetWindow and the flyout; none of these need a window rebuild to pick up a new accent
+        //
+        // the taskbar widget and the flyout share one TaskbarWidgetViewModel (see ShowFlyout / Preload), so
+        // refreshing it through TaskbarWidgetWindow.CurrentInstance already covers the flyouts graphs too
+        private static void ExecuteAccentRefresh()
+        {
+            TaskbarWidgetWindow.CurrentInstance?.ViewModel.RefreshGraphColors();
+
+            var widget = WidgetWindow.CurrentInstance;
+            widget?.ViewModel.RefreshGraphColors();
+            widget?.RefreshAccentSurfaces();
+
+            var flyout = CurrentInstance ?? _retainedInstance;
+            flyout?.RefreshAccentSurfaces();
+        }
 
         // --- workaround: window recreation on global OS theme/transparency change ---
         // problem: the exact underlying reason why Windows DWM fails to bind DesktopAcrylicController blur properly
@@ -693,11 +818,10 @@ namespace FluentSensors.Features.TaskbarWidget
             int durationMs = ScaleAnimationDuration(EnterAnimationDurationMs, EnterDurationPerSensorFactor);
 
             // 1. Content Fade (DirectComposition)
-            PlayContentFade(EnterFadeStartOpacity, EnterFadeEndOpacity, durationMs);
+            PlayContentFade(EnterFadeStartOpacity, EnterFadeEndOpacity, durationMs, isEntering: true);
 
             // 2. Physical Window Slide Up
-            int slideDistPx = GetSlideDistancePx(GetScaleFactor());
-            int startY = _targetY + slideDistPx;
+            int startY = _targetY + _slideDistancePx;
 
             EnsureBehindTaskbarZOrder();
             AnimateNativeWindowPosition(_targetX, startY, _targetX, _targetY, durationMs, isEntering: true);
@@ -710,13 +834,12 @@ namespace FluentSensors.Features.TaskbarWidget
             int durationMs = ScaleAnimationDuration(ExitAnimationDurationMs, ExitDurationPerSensorFactor);
 
             // 1. Content Fade (DirectComposition)
-            PlayContentFade(1.0f, ExitFadeEndOpacity, durationMs);
+            PlayContentFade(1.0f, ExitFadeEndOpacity, durationMs, isEntering: false);
 
             // 2. Physical Window Slide Down
-            int slideDistPx = GetSlideDistancePx(GetScaleFactor());
             int currentX = _appWindow.Position.X;
             int currentY = _appWindow.Position.Y;
-            int endY = _targetY + slideDistPx;
+            int endY = _targetY + _slideDistancePx;
 
             EnsureBehindTaskbarZOrder();
             AnimateNativeWindowPosition(currentX, currentY, currentX, endY, durationMs, isEntering: false, onComplete: onCompleted);
@@ -744,65 +867,91 @@ namespace FluentSensors.Features.TaskbarWidget
             return (int)Math.Round(WindowSlideDistanceDip * AnimationScaleFactor(SlideDistancePerSensorFactor) * scaleFactor);
         }
 
-        private void PlayContentFade(float fromOpacity, float toOpacity, int durationMs)
+        // enter and exit share the flyouts native window slide curve so the two never visibly diverge: Fluent 2
+        // Fast-Out-Slow-In on enter (cubic ease-out, 1-(1-p)^3) and Slow-Out-Fast-In on exit (cubic ease-in, p^3);
+        // expressed as the equivalent cubic-bezier control points, since CompositionEasingFunction only takes a
+        // bezier, not an arbitrary polynomial: (1/3,1)/(2/3,1) reduces to exactly 1-(1-p)^3, (1/3,0)/(2/3,0) to p^3
+        private void PlayContentFade(float fromOpacity, float toOpacity, int durationMs, bool isEntering)
         {
             if (RootGrid == null) return;
             var visual = ElementCompositionPreview.GetElementVisual(RootGrid);
             var compositor = visual?.Compositor;
             if (compositor == null) return;
 
+            var easing = isEntering
+                ? compositor.CreateCubicBezierEasingFunction(new Vector2(1f / 3f, 1f), new Vector2(2f / 3f, 1f))
+                : compositor.CreateCubicBezierEasingFunction(new Vector2(1f / 3f, 0f), new Vector2(2f / 3f, 0f));
+
             // NO inner offset animation on RootGrid - only smooth opacity fade
             var opacityAnim = compositor.CreateScalarKeyFrameAnimation();
             opacityAnim.InsertKeyFrame(0.0f, fromOpacity);
-            opacityAnim.InsertKeyFrame(1.0f, toOpacity);
+            opacityAnim.InsertKeyFrame(1.0f, toOpacity, easing);
             opacityAnim.Duration = TimeSpan.FromMilliseconds(durationMs);
             visual.StartAnimation("Opacity", opacityAnim);
         }
 
         private void AnimateNativeWindowPosition(int startX, int startY, int targetX, int targetY, int durationMs, bool isEntering, Action? onComplete = null)
         {
-            _animTimer?.Stop();
+            StopSlide();
+
             _animStartX = startX;
             _animStartY = startY;
             _animTargetX = targetX;
             _animTargetY = targetY;
+            _animDurationMs = durationMs;
+            _animIsEntering = isEntering;
             _animOnComplete = onComplete;
 
             _isAdjustingPosition = true;
-            _appWindow.Move(new PointInt32(startX, startY));
+            SetWindowPos(_hwnd, IntPtr.Zero, startX, startY, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
             _isAdjustingPosition = false;
 
+            _isAnimating = true;
             _animStopwatch = Stopwatch.StartNew();
-            _animTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(5) };
-            _animTimer.Tick += (s, e) =>
+            Microsoft.UI.Xaml.Media.CompositionTarget.Rendering += OnSlideFrame;
+        }
+
+        // ticks with the compositors own frame rate rather than a fixed interval, so the slide keeps pace with
+        // whatever refresh rate the display actually runs at; a DispatcherTimer cannot, see the field comment above
+        private void OnSlideFrame(object? sender, object e)
+        {
+            if (_animStopwatch == null) return;
+
+            double progress = Math.Clamp((double)_animStopwatch.ElapsedMilliseconds / _animDurationMs, 0.0, 1.0);
+
+            // Fluent 2 Easing curves:
+            // Enter: Fast Out, Slow In (Cubic ease-out) = 1 - (1 - p)^3
+            // Exit: Slow Out, Fast In (Cubic ease-in) = p^3
+            double ease = _animIsEntering
+                ? (1.0 - Math.Pow(1.0 - progress, 3))
+                : Math.Pow(progress, 3);
+
+            int currentX = (int)Math.Round(_animStartX + ((_animTargetX - _animStartX) * ease));
+            int currentY = (int)Math.Round(_animStartY + ((_animTargetY - _animStartY) * ease));
+
+            _isAdjustingPosition = true;
+            SetWindowPos(_hwnd, IntPtr.Zero, currentX, currentY, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+            _isAdjustingPosition = false;
+
+            if (progress >= 1.0)
             {
-                if (_animStopwatch == null) return;
+                var onComplete = _animOnComplete;
+                _animOnComplete = null;
+                StopSlide();
+                onComplete?.Invoke();
+            }
+        }
 
-                double progress = Math.Clamp((double)_animStopwatch.ElapsedMilliseconds / durationMs, 0.0, 1.0);
-
-                // Fluent 2 Easing curves:
-                // Enter: Fast Out, Slow In (Cubic ease-out) = 1 - (1 - p)^3
-                // Exit: Slow Out, Fast In (Cubic ease-in) = p^3
-                double ease = isEntering
-                    ? (1.0 - Math.Pow(1.0 - progress, 3))
-                    : Math.Pow(progress, 3);
-
-                int currentX = (int)Math.Round(_animStartX + ((_animTargetX - _animStartX) * ease));
-                int currentY = (int)Math.Round(_animStartY + ((_animTargetY - _animStartY) * ease));
-
-                _isAdjustingPosition = true;
-                _appWindow.Move(new PointInt32(currentX, currentY));
-                _isAdjustingPosition = false;
-
-                if (progress >= 1.0)
-                {
-                    _animTimer?.Stop();
-                    _animStopwatch?.Stop();
-                    _animOnComplete?.Invoke();
-                    _animOnComplete = null;
-                }
-            };
-            _animTimer.Start();
+        // unhooks the per-frame handler; CompositionTarget.Rendering is static and keeps firing for the life of
+        // the process once subscribed, so every path that can end a slide (completion, an overlapping new slide,
+        // window teardown in SafeDestroy) has to call this or the compositor never stops ticking a dead flyout
+        private void StopSlide()
+        {
+            if (!_isAnimating) return;
+            _isAnimating = false;
+            Microsoft.UI.Xaml.Media.CompositionTarget.Rendering -= OnSlideFrame;
+            _animStopwatch?.Stop();
+            _animStopwatch = null;
         }
 
 
@@ -851,6 +1000,11 @@ namespace FluentSensors.Features.TaskbarWidget
             _animationSensorCount = isScrolling ? CountFittingGraphSlots(maxHeightPx, scale) : sensorCount;
             ApplyGraphsScrollMode(isScrolling);
 
+            // computed from the taskbars own DPI (scale, above), the same source _targetX/Y and desiredWidthPx/
+            // desiredHeightPx already use; SlideInFromBottom/SlideOutToBottom read this instead of recomputing
+            // against the window DPI, which could disagree with it on a mixed-DPI setup and jump the first frame
+            _slideDistancePx = GetSlideDistancePx(scale);
+
             // Left/Right anchor to the matching widget edge and let the offset pull the flyout inward;
             // Center ignores the offset and lines the flyout center up with the widget center
             _targetX = SettingsService.Instance.TaskbarFlyoutAlignment switch
@@ -869,7 +1023,7 @@ namespace FluentSensors.Features.TaskbarWidget
             _targetX = Math.Max(leftLimitX, Math.Min(_targetX, rightLimitX));
 
             int initialY = startForSlideAnimation
-                ? (_targetY + GetSlideDistancePx(scale))
+                ? (_targetY + _slideDistancePx)
                 : _targetY;
 
             _isAdjustingPosition = true;
@@ -915,7 +1069,7 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private void AppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs args)
         {
-            if (_isAdjustingPosition || _animTimer?.IsEnabled == true) return;
+            if (_isAdjustingPosition || _isAnimating) return;
 
             if (args.DidSizeChange && _bottomAnchorY > 0)
             {
@@ -1276,6 +1430,14 @@ namespace FluentSensors.Features.TaskbarWidget
             {
                 EnsureNoiseBitmap(FlyoutRootBorder.ActualWidth, FlyoutRootBorder.ActualHeight);
             }
+        }
+
+        // re-reads the live SystemAccentColor into the acrylic tint and the solid background, for a pure OS
+        // accent change; both already resolve the accent fresh on every call, so no window rebuild is needed
+        private void RefreshAccentSurfaces()
+        {
+            UpdateAcrylicProperties();
+            UpdateSolidBackground();
         }
 
         // === acrylic grain ===

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -202,8 +202,8 @@ namespace FluentSensors.Features.TaskbarWidget
         private static TaskbarFlyoutWindow? _retainedInstance;
 
         // system backdrop controllers
+        // no MicaController here on purpose: material "Mica" is served by _acrylicController too, see SetBackdrop
         private DesktopAcrylicController? _acrylicController;
-        private MicaController? _micaController;
         private SystemBackdropConfiguration? _configurationSource;
 
 
@@ -462,6 +462,8 @@ namespace FluentSensors.Features.TaskbarWidget
         // preloads the flyout instance into memory at taskbar initialization to eliminate first-open latency
         public static void Preload(TaskbarWidgetWindow widgetWindow)
         {
+            // a retained instance is assumed to be a live window; if a destroyed one ever sits there this silently
+            // skips the rebuild and the flyout stays dead for the rest of the session, see AppWindow_Closing
             if (widgetWindow == null || CurrentInstance != null || _retainedInstance != null) return;
 
             var window = new TaskbarFlyoutWindow(widgetWindow.ViewModel);
@@ -558,6 +560,17 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private bool _isClosed = false;
 
+        // --- memory leak: flyout instance never released after a real close ---
+        // problem: WinUI 3 never releases secondary Window objects back to the GC/OS after a real close
+        // confirmed, still-open platform bug, reproducible even with empty window content:
+        // https://github.com/microsoft/microsoft-ui-xaml/issues/9063
+        // everywhere else in this project the answer is hide-and-reuse (_retainedInstance); this method is the one
+        // place that deliberately does the opposite and destroys the window for real, because DWM does not rebind
+        // DesktopAcrylicController to a fresh swapchain without a full recreation, see ScheduleRecreation below
+        // price: one leaked CCW per OS theme or transparency change, knowingly paid, because the alternative was a
+        // flyout that silently stopped repainting and switching theme for the rest of the session
+        //
+        // only ever call this from ExecuteFullRebuild, never from the normal hide path
         public void SafeDestroy()
         {
             if (_isClosed) return;
@@ -588,8 +601,6 @@ namespace FluentSensors.Features.TaskbarWidget
                 _messageMonitor = null;
                 _acrylicController?.Dispose();
                 _acrylicController = null;
-                _micaController?.Dispose();
-                _micaController = null;
                 this.Close();
             }
             catch { }
@@ -636,6 +647,11 @@ namespace FluentSensors.Features.TaskbarWidget
             });
         }
 
+        // tears both flyout instances down for real and builds a fresh one, the destructive half of the workaround
+        // documented on ScheduleRecreation above
+        //
+        // the only caller of SafeDestroy; the widget window is rebuilt in between on purpose, the flyout anchors its
+        // geometry to it and needs the new one to already exist
         private static void ExecuteFullRebuild()
         {
             var widgetWindow = TaskbarWidgetWindow.CurrentInstance;
@@ -917,6 +933,10 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private void Window_Activated(object sender, WindowActivatedEventArgs args)
         {
+            // deliberately always true, instead of the usual
+            // IsInputActive = args.WindowActivationState != WindowActivationState.Deactivated
+            // a light-dismiss flyout counts as deactivated the moment focus leaves it, which would drop the blur while
+            // the window is still on screen; same reasoning as WidgetWindow.Window_Activated
             if (_configurationSource != null)
             {
                 _configurationSource.IsInputActive = true;
@@ -968,6 +988,12 @@ namespace FluentSensors.Features.TaskbarWidget
             TaskbarWidgetWindow.CurrentInstance?.CloseWidget();
         }
 
+        // --- memory leak: TaskbarFlyoutWindow never released after close ---
+        // problem: WinUI 3 never releases secondary Window objects back to the GC/OS after a real close
+        // confirmed, still-open platform bug, reproducible even with empty window content:
+        // https://github.com/microsoft/microsoft-ui-xaml/issues/9063
+        // fix: hide instead of actually closing, and keep this instance around (_retainedInstance) for reuse
+        // same approach as WidgetWindow and TaskbarWidgetWindow
         private void AppWindow_Closing(AppWindow sender, AppWindowClosingEventArgs args)
         {
             // SafeDestroy is tearing this instance down: let the close proceed, and above all do not hand a window
@@ -1130,7 +1156,7 @@ namespace FluentSensors.Features.TaskbarWidget
             var themeDictionary = (ResourceDictionary)Application.Current.Resources
                 .ThemeDictionaries[isLight ? "Light" : "Default"];
 
-            if (_acrylicController != null || _micaController != null)
+            if (_acrylicController != null)
             {
                 FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
             }
@@ -1150,6 +1176,13 @@ namespace FluentSensors.Features.TaskbarWidget
             FlyoutRootBorder.BorderBrush = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutWindowBorderBrush"];
         }
 
+        // applies the backdrop material for the current setting and the Windows transparency state
+        //
+        // "Mica" deliberately runs through DesktopAcrylicController as well, with the MicaPreset constants at the top
+        // of this file instead of the settings sliders: real Mica only samples the wallpaper and shows next to nothing
+        // on a small flyout sitting above the taskbar, while acrylic blurs what is actually behind the window
+        // WidgetWindow uses a real MicaController for the same setting name, so the two windows differ on purpose
+        // the tint and luminosity sliders from settings only reach the "Acrylic" branch of UpdateAcrylicProperties
         public void SetBackdrop(string backdropType)
         {
             if (_isClosed) return;
@@ -1168,8 +1201,6 @@ namespace FluentSensors.Features.TaskbarWidget
 
             _acrylicController?.Dispose();
             _acrylicController = null;
-            _micaController?.Dispose();
-            _micaController = null;
             this.SystemBackdrop = null;
 
             if (isTransparencyEnabled && (backdropType == "Acrylic" || backdropType == "Mica") && DesktopAcrylicController.IsSupported())

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Windows.Graphics;
 using Windows.UI.ViewManagement;
 using WinRT;
@@ -149,16 +150,27 @@ namespace FluentSensors.Features.TaskbarWidget
         public static readonly Thickness FlyoutGraphsPadding = new Thickness(4.5, 1, 4.5, 6);
 
         // --- Mica Flyout Blur Preset Settings (used when BackdropType == "Mica" and Transparency is ON) ---
-        // the tint colors match the opaque theme base, so both modes aim at the same tone
-        // Dark Mode Preset (Target #222222 on-screen):
-        public static readonly Windows.UI.Color MicaPresetDarkTintColor = Windows.UI.Color.FromArgb(255, 0x22, 0x22, 0x22);
-        public const float MicaPresetDarkLuminosity = 0.90f;
-        public const float MicaPresetDarkTintOpacity = 0.70f;
+        // over a flat backdrop the controller resolves to lerp(backdrop, tint, luminosity), so measuring one
+        // surface over a dark and over a bright background yields both unknowns; run against the native shell
+        // flyouts that gives 4 percent backdrop transmission in dark and 9 percent in light
+        //
+        // no TintOpacity here on purpose: the tint sits in a blend that carries hue and saturation only, so a
+        // neutral gray tint turns that layer into a no-op and luminosity is the one knob that moves the result
+        // the effect graph is public; note that the source flags its own BlendEffectMode names as swapped, so the
+        // tint layer reads as Luminosity there while it behaves as a color blend:
+        // https://github.com/microsoft/microsoft-ui-xaml/blob/6aed8d97fdecfe9b19d70c36bd1dacd9c6add7c1/dev/Materials/Acrylic/AcrylicBrush.cpp
+        //
+        // the tints are the Fluent acrylic base tones, AcrylicBackgroundFillColorBaseBrush:
+        // https://github.com/microsoft/microsoft-ui-xaml/blob/6aed8d97fdecfe9b19d70c36bd1dacd9c6add7c1/dev/Materials/Acrylic/AcrylicBrush_19h1_themeresources.xaml
+        // they are not pre-compensated the way the opaque literals are, because the render shift applies once to
+        // the finished composite and is already contained in the measurements these were derived from
+        // Dark Mode Preset:
+        public static readonly Windows.UI.Color MicaPresetDarkTintColor = Windows.UI.Color.FromArgb(255, 0x20, 0x20, 0x20);
+        public const float MicaPresetDarkLuminosity = 0.96f;
 
-        // Light Mode Preset (Target #EDEDED on-screen):
-        public static readonly Windows.UI.Color MicaPresetLightTintColor = Windows.UI.Color.FromArgb(255, 0xED, 0xED, 0xED);
-        public const float MicaPresetLightLuminosity = 0.90f;
-        public const float MicaPresetLightTintOpacity = 0.70f;
+        // Light Mode Preset:
+        public static readonly Windows.UI.Color MicaPresetLightTintColor = Windows.UI.Color.FromArgb(255, 0xF3, 0xF3, 0xF3);
+        public const float MicaPresetLightLuminosity = 0.91f;
 
 
         // === fields ===
@@ -284,6 +296,7 @@ namespace FluentSensors.Features.TaskbarWidget
             GraphsContentGrid.Padding = FlyoutGraphsPadding;
 
             _appWindow.Changed += AppWindow_Changed;
+            FlyoutRootBorder.SizeChanged += FlyoutRootBorder_SizeChanged;
             _appWindow.Closing += AppWindow_Closing;
             this.Activated += Window_Activated;
 
@@ -601,6 +614,7 @@ namespace FluentSensors.Features.TaskbarWidget
                 _messageMonitor = null;
                 _acrylicController?.Dispose();
                 _acrylicController = null;
+                _noiseBitmap = null;
                 this.Close();
             }
             catch { }
@@ -1106,14 +1120,12 @@ namespace FluentSensors.Features.TaskbarWidget
                     if (isLight)
                     {
                         _acrylicController.TintColor = MicaPresetLightTintColor;
-                        _acrylicController.TintOpacity = MicaPresetLightTintOpacity;
                         _acrylicController.LuminosityOpacity = MicaPresetLightLuminosity;
                         _acrylicController.FallbackColor = MicaPresetLightTintColor;
                     }
                     else
                     {
                         _acrylicController.TintColor = MicaPresetDarkTintColor;
-                        _acrylicController.TintOpacity = MicaPresetDarkTintOpacity;
                         _acrylicController.LuminosityOpacity = MicaPresetDarkLuminosity;
                         _acrylicController.FallbackColor = MicaPresetDarkTintColor;
                     }
@@ -1164,7 +1176,9 @@ namespace FluentSensors.Features.TaskbarWidget
             var transparent = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
             var graphsOverlay = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutGraphsBackground"];
 
-            if (_acrylicController != null)
+            bool onGlass = _acrylicController != null;
+
+            if (onGlass)
             {
                 FlyoutRootBorder.Background = transparent;
                 FlyoutBottomBarBorder.Background = transparent;
@@ -1187,9 +1201,113 @@ namespace FluentSensors.Features.TaskbarWidget
                 GraphsContentGrid.Background = transparent;
             }
 
-            // both strokes are solid in every mode, unlike the fills above
+            // the window stroke is one opaque line in every mode
+            // the separator is not: on glass the native line stays translucent and darkens the material rather
+            // than covering it, so an opaque stroke there stands still while everything around it moves
             FlyoutRootBorder.BorderBrush = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutWindowBorderBrush"];
-            FlyoutBottomBarBorder.BorderBrush = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutBottomBarSeparatorBrush"];
+            FlyoutBottomBarBorder.BorderBrush = (Microsoft.UI.Xaml.Media.Brush)themeDictionary[
+                onGlass ? "FlyoutBottomBarSeparatorOnGlassBrush" : "FlyoutBottomBarSeparatorBrush"];
+
+            // the grain belongs to the material, so it shows in the blur modes only
+            FlyoutNoiseHost.Visibility = onGlass ? Visibility.Visible : Visibility.Collapsed;
+            if (onGlass)
+            {
+                EnsureNoiseBitmap(FlyoutRootBorder.ActualWidth, FlyoutRootBorder.ActualHeight);
+            }
+        }
+
+        // === acrylic grain ===
+
+        // the acrylic recipe composites a noise layer as its final step at 2 percent opacity, but the system
+        // backdrop controller does not draw it, which is why the flyout reads as one perfectly flat tone while
+        // the native shell surfaces scatter across a few levels
+        // sc_noiseOpacity 0.02f and sc_blurRadius 30.0f are the published recipe constants:
+        // https://github.com/microsoft/microsoft-ui-xaml/blob/6aed8d97fdecfe9b19d70c36bd1dacd9c6add7c1/dev/Materials/Acrylic/AcrylicBrush.h
+        // this fills that layer in: one random grayscale bitmap, painted under every surface fill
+        private const int NoiseSeed = 0x5EED;
+
+        // layer opacity stays the recipe constant; how strong the grain reads is set through the value range
+        // instead, which keeps the mean at 128 so tuning the grain never moves the calibrated surface colors
+        private const double NoiseLayerOpacity = 0.02;
+        private const double NoiseSpreadLevels = 3.5;
+
+        private Microsoft.UI.Xaml.Media.Imaging.WriteableBitmap? _noiseBitmap;
+        private double _noiseScale;
+
+        // grows on demand and never shrinks, so only a resize past the current bitmap rebuilds it
+        // sized in physical pixels and scaled back down, so one noise pixel lands on one physical pixel instead
+        // of being smeared across the DPI scale factor, which is what makes the grain look coarse
+        private void EnsureNoiseBitmap(double widthDip, double heightDip)
+        {
+            if (_isClosed || widthDip <= 0 || heightDip <= 0) return;
+
+            double scale = FlyoutRootBorder.XamlRoot?.RasterizationScale ?? 1.0;
+            if (scale <= 0) scale = 1.0;
+
+            int width = (int)Math.Ceiling(widthDip * scale);
+            int height = (int)Math.Ceiling(heightDip * scale);
+
+            bool scaleUnchanged = Math.Abs(scale - _noiseScale) < 0.001;
+            if (_noiseBitmap != null && scaleUnchanged
+                && _noiseBitmap.PixelWidth >= width && _noiseBitmap.PixelHeight >= height)
+            {
+                return;
+            }
+
+            if (scaleUnchanged)
+            {
+                width = Math.Max(width, _noiseBitmap?.PixelWidth ?? 0);
+                height = Math.Max(height, _noiseBitmap?.PixelHeight ?? 0);
+            }
+
+            var bitmap = new Microsoft.UI.Xaml.Media.Imaging.WriteableBitmap(width, height);
+            var random = new Random(NoiseSeed);
+            var pixels = new byte[width * height * 4];
+
+            int half = (int)Math.Round(NoiseSpreadLevels / (2.0 * NoiseLayerOpacity));
+
+            for (int i = 0; i < pixels.Length; i += 4)
+            {
+                byte level = (byte)(128 - half + random.Next((half * 2) + 1));
+                pixels[i] = level;
+                pixels[i + 1] = level;
+                pixels[i + 2] = level;
+                pixels[i + 3] = 255;
+            }
+
+            using (var stream = bitmap.PixelBuffer.AsStream())
+            {
+                stream.Write(pixels, 0, pixels.Length);
+            }
+            bitmap.Invalidate();
+
+            _noiseBitmap = bitmap;
+            _noiseScale = scale;
+
+            FlyoutNoiseHost.Opacity = NoiseLayerOpacity;
+            FlyoutNoiseOverlay.Width = width;
+            FlyoutNoiseOverlay.Height = height;
+            FlyoutNoiseOverlay.RenderTransform = new Microsoft.UI.Xaml.Media.ScaleTransform
+            {
+                ScaleX = 1.0 / scale,
+                ScaleY = 1.0 / scale
+            };
+
+            // Stretch None keeps one bitmap pixel on one physical pixel, any stretching smears the grain away
+            FlyoutNoiseOverlay.Fill = new Microsoft.UI.Xaml.Media.ImageBrush
+            {
+                ImageSource = bitmap,
+                Stretch = Microsoft.UI.Xaml.Media.Stretch.None,
+                AlignmentX = Microsoft.UI.Xaml.Media.AlignmentX.Left,
+                AlignmentY = Microsoft.UI.Xaml.Media.AlignmentY.Top
+            };
+        }
+
+        private void FlyoutRootBorder_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            if (_isClosed || FlyoutNoiseHost.Visibility != Visibility.Visible) return;
+
+            EnsureNoiseBitmap(e.NewSize.Width, e.NewSize.Height);
         }
 
         // applies the backdrop material for the current setting and the Windows transparency state
@@ -1222,6 +1340,9 @@ namespace FluentSensors.Features.TaskbarWidget
             if (isTransparencyEnabled && (backdropType == "Acrylic" || backdropType == "Mica") && DesktopAcrylicController.IsSupported())
             {
                 _acrylicController = new DesktopAcrylicController();
+                // Base is the acrylic variant the Windows 11 shell surfaces use; Default lets the system pick
+                // https://learn.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.composition.systembackdrops.desktopacrylickind
+                _acrylicController.Kind = DesktopAcrylicKind.Base;
                 _acrylicController.AddSystemBackdropTarget(this.As<ICompositionSupportsSystemBackdrop>());
                 _acrylicController.SetSystemBackdropConfiguration(_configurationSource);
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -145,10 +145,6 @@ namespace FluentSensors.Features.TaskbarWidget
         // keeps graphs rendering continuously in background so they are instantly visible on open
         public const bool KeepFlyoutGraphsActiveInBackground = true;
 
-        // padding settings for fine-tuning
-        public static readonly Thickness FlyoutRootPadding = new Thickness(0, -1, 0, 0); // padding applied to flyout root border
-        public static readonly Thickness FlyoutGraphsPadding = new Thickness(4.5, 1, 4.5, 6);
-
         // --- Mica Flyout Blur Preset Settings (used when BackdropType == "Mica" and Transparency is ON) ---
         // over a flat backdrop the controller resolves to lerp(backdrop, tint, luminosity), so measuring one
         // surface over a dark and over a bright background yields both unknowns; run against the native shell
@@ -187,9 +183,29 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // default and minimum height per graph slot in DIP
         public const int FlyoutDefaultGraphHeightDip = 100;
-        public const int MinFlyoutGraphHeightDip = 90;
-        public const int FlyoutBottomBarHeightDip = 48; // bottom action bar strip; fixed height added on top of the graph slots in the window height math
-        public const int FlyoutGraphSpacingDip = 8;
+        public const int MinFlyoutGraphHeightDip = 100;
+
+        // --- flyout layout ---
+
+        // the two knobs for the interior; every visible inset inside the window comes from one of them
+        public static readonly Thickness FlyoutGraphsPadding = new Thickness(6, 9, 6, 7);
+        public static readonly Thickness FlyoutBottomBarPadding = new Thickness(0, 0, 0, 0);
+
+        // gap between two stacked graphs
+        public const double FlyoutGraphSpacingDip = 8;
+
+        // (AppBarButton renders at the platform AppBarThemeCompactHeight; mirrored here because the window height
+        // math runs long before the bar is ever measured)
+        public const double FlyoutBottomBarButtonHeightDip = 48;
+
+        // separator drawn as the top border of FlyoutBottomBarBorder
+        private const double FlyoutBottomBarSeparatorDip = 1;
+
+        // bottom action bar strip, added on top of the graph slots in the window height math; derived, so
+        // changing FlyoutBottomBarPadding corrects that math on its own
+        private static double FlyoutBottomBarHeightDip =>
+            FlyoutBottomBarSeparatorDip + FlyoutBottomBarPadding.Top
+            + FlyoutBottomBarButtonHeightDip + FlyoutBottomBarPadding.Bottom;
 
         private AppWindow _appWindow;
         private IntPtr _hwnd;
@@ -291,9 +307,10 @@ namespace FluentSensors.Features.TaskbarWidget
                 });
             };
 
-            // apply configurable paddings
-            RootGrid.Padding = FlyoutRootPadding;
+            // the interior is driven entirely from the layout metrics above, the XAML carries no numbers of its own
             GraphsContentGrid.Padding = FlyoutGraphsPadding;
+            BottomBarContentGrid.Padding = FlyoutBottomBarPadding;
+            GraphsItemsControl.LayoutUpdated += OnGraphsItemsControlLayoutUpdated;
 
             _appWindow.Changed += AppWindow_Changed;
             FlyoutRootBorder.SizeChanged += FlyoutRootBorder_SizeChanged;
@@ -891,14 +908,23 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private int CalculateFlyoutMinHeight(int sensorCount, double scaleFactor)
         {
-            double minXamlHeight = FlyoutBottomBarHeightDip + (sensorCount * (MinFlyoutGraphHeightDip + FlyoutGraphSpacingDip));
-            return (int)(minXamlHeight * scaleFactor);
+            return (int)(CalculateFlyoutContentHeight(sensorCount, MinFlyoutGraphHeightDip) * scaleFactor);
         }
 
         private int CalculateFlyoutDefaultHeight(int sensorCount, double scaleFactor)
         {
-            double defaultXamlHeight = FlyoutBottomBarHeightDip + (sensorCount * (FlyoutDefaultGraphHeightDip + FlyoutGraphSpacingDip));
-            return (int)(defaultXamlHeight * scaleFactor);
+            return (int)(CalculateFlyoutContentHeight(sensorCount, FlyoutDefaultGraphHeightDip) * scaleFactor);
+        }
+
+        // window height for n graph slots: the bar strip, the graphs padding, n slots and the n-1 gaps between them
+        private static double CalculateFlyoutContentHeight(int sensorCount, double graphHeightDip)
+        {
+            if (sensorCount <= 0) return FlyoutBottomBarHeightDip;
+
+            return FlyoutBottomBarHeightDip
+                + FlyoutGraphsPadding.Top + FlyoutGraphsPadding.Bottom
+                + (sensorCount * graphHeightDip)
+                + ((sensorCount - 1) * FlyoutGraphSpacingDip);
         }
 
         private void AppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs args)
@@ -930,6 +956,17 @@ namespace FluentSensors.Features.TaskbarWidget
             state.WasOpen = false;
 
             WindowStateService.Instance.SetState(WindowKey, state);
+        }
+
+        // the graph panel sits inside an ItemsPanelTemplate and cannot be named, so FlyoutGraphSpacingDip is
+        // pushed onto it from here; the items host only exists after the first layout pass, hence the retry
+        private void OnGraphsItemsControlLayoutUpdated(object? sender, object e)
+        {
+            if (GraphsItemsControl.ItemsPanelRoot is FluentSensors.Controls.VerticalStretchPanel panel)
+            {
+                panel.Spacing = FlyoutGraphSpacingDip;
+                GraphsItemsControl.LayoutUpdated -= OnGraphsItemsControlLayoutUpdated;
+            }
         }
 
         private void SetGraphsRenderingActive(bool active)

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -149,13 +149,14 @@ namespace FluentSensors.Features.TaskbarWidget
         public static readonly Thickness FlyoutGraphsPadding = new Thickness(4.5, 1, 4.5, 6);
 
         // --- Mica Flyout Blur Preset Settings (used when BackdropType == "Mica" and Transparency is ON) ---
+        // the tint colors match the opaque theme base, so both modes aim at the same tone
         // Dark Mode Preset (Target #222222 on-screen):
-        public static readonly Windows.UI.Color MicaPresetDarkTintColor = Windows.UI.Color.FromArgb(255, 0x1A, 0x1A, 0x1A);
-        public const float MicaPresetDarkLuminosity = 0.0f;
-        public const float MicaPresetDarkTintOpacity = 0.85f;
+        public static readonly Windows.UI.Color MicaPresetDarkTintColor = Windows.UI.Color.FromArgb(255, 0x22, 0x22, 0x22);
+        public const float MicaPresetDarkLuminosity = 0.90f;
+        public const float MicaPresetDarkTintOpacity = 0.70f;
 
-        // Light Mode Preset (Target #F2F2F2 on-screen):
-        public static readonly Windows.UI.Color MicaPresetLightTintColor = Windows.UI.Color.FromArgb(255, 0xF2, 0xF2, 0xF2);
+        // Light Mode Preset (Target #EDEDED on-screen):
+        public static readonly Windows.UI.Color MicaPresetLightTintColor = Windows.UI.Color.FromArgb(255, 0xED, 0xED, 0xED);
         public const float MicaPresetLightLuminosity = 0.90f;
         public const float MicaPresetLightTintOpacity = 0.70f;
 
@@ -211,7 +212,6 @@ namespace FluentSensors.Features.TaskbarWidget
         public TaskbarFlyoutWindow(TaskbarWidgetViewModel viewModel)
         {
             ViewModel = viewModel;
-            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === Constructor ENTER. HashCode={this.GetHashCode()} AppTheme={SettingsService.Instance.AppTheme} Backdrop={SettingsService.Instance.TaskbarBackdropType}");
             this.InitializeComponent();
             CurrentInstance = this;
 
@@ -502,7 +502,6 @@ namespace FluentSensors.Features.TaskbarWidget
         public static void ShowFlyout(TaskbarWidgetWindow widgetWindow)
         {
             if (widgetWindow == null) return;
-            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === ShowFlyout: CurrentInstance={(CurrentInstance != null ? CurrentInstance.GetHashCode() : 0)}, Retained={(_retainedInstance != null ? _retainedInstance.GetHashCode() : 0)}, AppTheme={SettingsService.Instance.AppTheme}");
 
             if (CurrentInstance != null)
             {
@@ -573,6 +572,16 @@ namespace FluentSensors.Features.TaskbarWidget
             }
             catch { }
 
+            // AppWindow_Closing cancels the close and re-registers this instance as _retainedInstance; detaching it
+            // here is what lets the Close below go through instead of resurrecting a window that is already torn down
+            try
+            {
+                _appWindow.Closing -= AppWindow_Closing;
+                _appWindow.Changed -= AppWindow_Changed;
+                this.Activated -= Window_Activated;
+            }
+            catch { }
+
             try
             {
                 _messageMonitor?.Dispose();
@@ -588,16 +597,18 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private static Microsoft.UI.Dispatching.DispatcherQueueTimer? _recreateDebounceTimer;
 
-        // --- workaround: window recreation and backdrop toggle on global OS theme/transparency change ---
+        // --- workaround: window recreation on global OS theme/transparency change ---
         // problem: the exact underlying reason why Windows DWM fails to bind DesktopAcrylicController blur properly
-        // without a complete window recreation and a brief material toggle (None -> Mica) is not fully clear and is
-        // based purely on empirical observation
+        // without a complete window recreation is not fully clear and is based purely on empirical observation
         // fix: upon receiving a global theme or transparency change from Windows, both windows (TaskbarFlyoutWindow
-        // and WidgetWindow, if open) are fully destroyed and rebuilt, and if Mica was selected, the backdrop material
-        // setting is briefly toggled to None (Solid) and immediately back to Mica to force a full DWM compositor refresh
+        // and WidgetWindow, if open) are fully destroyed and rebuilt; each rebuilt window then kicks its own backdrop
+        // from its constructor via KickBackdropRefresh, which goes through SetBackdrop parameters only
+        //
+        // only ever driven by the Windows-level UISettings events; an in-app theme switch must not land here, and a
+        // persisted SettingsService property must never be toggled to force a repaint: every setter snapshots the whole
+        // settings object into the debounced writer, so an interrupted toggle persists its intermediate value
         public static void ScheduleRecreation()
         {
-            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === ScheduleRecreation called.");
             var queue = TaskbarWidgetWindow.CurrentInstance?.DispatcherQueue
                 ?? MainWindow.CurrentInstance?.DispatcherQueue
                 ?? DispatcherQueue.GetForCurrentThread();
@@ -627,7 +638,6 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private static void ExecuteFullRebuild()
         {
-            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === ExecuteFullRebuild called.");
             var widgetWindow = TaskbarWidgetWindow.CurrentInstance;
             bool flyoutWasVisible = CurrentInstance != null && CurrentInstance._appWindow != null && CurrentInstance._appWindow.IsVisible;
 
@@ -662,26 +672,6 @@ namespace FluentSensors.Features.TaskbarWidget
                     {
                         Preload(widgetWindow);
                     }
-
-                    // 4. Force SettingsService backdrop material toggle (Solid -> Mica)
-                    var kickTimer = widgetWindow.DispatcherQueue.CreateTimer();
-                    kickTimer.Interval = TimeSpan.FromMilliseconds(80);
-                    kickTimer.IsRepeating = false;
-                    kickTimer.Tick += (s, e) =>
-                    {
-                        kickTimer.Stop();
-                        if (SettingsService.Instance.TaskbarBackdropType == "Mica")
-                        {
-                            SettingsService.Instance.TaskbarBackdropType = "None";
-                            SettingsService.Instance.TaskbarBackdropType = "Mica";
-                        }
-                        if (SettingsService.Instance.BackdropType == "Mica")
-                        {
-                            SettingsService.Instance.BackdropType = "None";
-                            SettingsService.Instance.BackdropType = "Mica";
-                        }
-                    };
-                    kickTimer.Start();
                 });
             }
         }
@@ -980,6 +970,11 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private void AppWindow_Closing(AppWindow sender, AppWindowClosingEventArgs args)
         {
+            // SafeDestroy is tearing this instance down: let the close proceed, and above all do not hand a window
+            // with _isClosed set back to _retainedInstance, which makes Preload skip building a live one and leaves
+            // the flyout permanently unable to repaint or switch theme
+            if (_isClosed) return;
+
             args.Cancel = true;
             HideFlyout();
             CurrentInstance = null;
@@ -989,15 +984,12 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // === theme and backdrop application (Taskbar Ecosystem) ===
 
+        // ApplyTheme already re-runs SetConfigurationSourceTheme, UpdateAcrylicProperties and UpdateSolidBackground,
+        // so an in-app theme switch is a plain repaint; recreating the window here tore down the live instance
+        // mid-switch, which is what produced the closed-window COMException
         private void OnThemeChanged(string newTheme)
         {
-            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === OnThemeChanged ENTER: newTheme={newTheme}, HashCode={this.GetHashCode()}");
-            this.DispatcherQueue.TryEnqueue(() =>
-            {
-                ApplyTheme(newTheme);
-                UpdateSolidBackground();
-                ScheduleRecreation();
-            });
+            this.DispatcherQueue.TryEnqueue(() => ApplyTheme(newTheme));
         }
 
         private void OnBackdropTypeChanged(string newType)
@@ -1022,7 +1014,6 @@ namespace FluentSensors.Features.TaskbarWidget
         private void ApplyTheme(string themeTag)
         {
             if (_isClosed) return;
-            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === ApplyTheme ENTER: themeTag={themeTag}, HashCode={this.GetHashCode()}");
 
             var elementTheme = themeTag switch
             {
@@ -1104,9 +1095,9 @@ namespace FluentSensors.Features.TaskbarWidget
                 else
                 {
                     // "Acrylic" uses user-configured settings sliders
-                    // fallback tint when no accent/custom color applies: #F2F2F2 Light, #222222 Dark (matches the opaque path)
+                    // fallback tint when no accent/custom color applies: #EDEDED Light, #222222 Dark (matches the opaque path)
                     Windows.UI.Color defaultTint = isLight
-                        ? Windows.UI.Color.FromArgb(255, 0xF2, 0xF2, 0xF2)
+                        ? Windows.UI.Color.FromArgb(255, 0xED, 0xED, 0xED)
                         : Windows.UI.Color.FromArgb(255, 0x22, 0x22, 0x22);
 
                     Windows.UI.Color targetColor = SettingsService.Instance.TaskbarUseAccentColor
@@ -1121,14 +1112,29 @@ namespace FluentSensors.Features.TaskbarWidget
             }
         }
 
+        // paints the flyout base for the current backdrop mode
+        //
+        // three mutually exclusive cases, in this order:
+        // 1. a backdrop controller is attached: the border stays transparent, anything else paints over the blur
+        // 2. material "None" (Solid): the color is the users own pick in settings, accent or custom, theme independent
+        // 3. otherwise (Mica/Acrylic while Windows transparency is off): the flyout draws its own theme background
+        //
+        // case 3 reads its brushes straight out of the App.xaml theme dictionary, so every hex value lives in exactly
+        // one place; the {ThemeResource} markup on FlyoutRootBorder is the first paint only, every later value is a
+        // local assignment from here and a local value permanently outranks the markup expression
         private void UpdateSolidBackground()
         {
             if (_isClosed || FlyoutRootBorder == null) return;
 
             bool isLight = IsCurrentThemeLight();
-            string backdropType = SettingsService.Instance.TaskbarBackdropType;
+            var themeDictionary = (ResourceDictionary)Application.Current.Resources
+                .ThemeDictionaries[isLight ? "Light" : "Default"];
 
-            if (backdropType == "None" && (SettingsService.Instance.TaskbarUseAccentColor || SettingsService.Instance.TaskbarCustomTintColor.A > 0))
+            if (_acrylicController != null || _micaController != null)
+            {
+                FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            }
+            else if (SettingsService.Instance.TaskbarBackdropType == "None")
             {
                 Windows.UI.Color targetColor = SettingsService.Instance.TaskbarUseAccentColor
                     ? (Windows.UI.Color)Application.Current.Resources["SystemAccentColor"]
@@ -1136,27 +1142,12 @@ namespace FluentSensors.Features.TaskbarWidget
 
                 FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(targetColor);
             }
-            else if (_acrylicController == null && _micaController == null)
-            {
-                // Solid Mode (Transparency OFF or Solid material): #F2F2F2 Light, #222222 Dark
-                Windows.UI.Color bgColor = isLight
-                    ? Windows.UI.Color.FromArgb(255, 0xF2, 0xF2, 0xF2)
-                    : Windows.UI.Color.FromArgb(255, 0x22, 0x22, 0x22);
-
-                FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(bgColor);
-            }
             else
             {
-                // Translucent Mode: FlyoutRootBorder is transparent to let Acrylic backdrop show through
-                FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+                FlyoutRootBorder.Background = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutWindowBackground"];
             }
 
-            // Real border: #BFBFBF for Light, #383838 for Dark
-            Windows.UI.Color borderColor = isLight
-                ? Windows.UI.Color.FromArgb(255, 0xBF, 0xBF, 0xBF)
-                : Windows.UI.Color.FromArgb(255, 0x38, 0x38, 0x38);
-
-            FlyoutRootBorder.BorderBrush = new Microsoft.UI.Xaml.Media.SolidColorBrush(borderColor);
+            FlyoutRootBorder.BorderBrush = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutWindowBorderBrush"];
         }
 
         public void SetBackdrop(string backdropType)
@@ -1188,13 +1179,14 @@ namespace FluentSensors.Features.TaskbarWidget
                 _acrylicController.SetSystemBackdropConfiguration(_configurationSource);
 
                 UpdateAcrylicProperties();
-                FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
             }
             else
             {
                 this.SystemBackdrop = new TransparentTintBackdrop();
-                UpdateSolidBackground();
             }
+
+            // single entry point for the base color, it reads the controller fields set just above
+            UpdateSolidBackground();
 
             UpdateShadowPolicy();
         }

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -1138,16 +1138,21 @@ namespace FluentSensors.Features.TaskbarWidget
             }
         }
 
-        // paints the flyout base for the current backdrop mode
+        // paints every visible flyout surface for the current backdrop mode
         //
         // three mutually exclusive cases, in this order:
-        // 1. a backdrop controller is attached: the border stays transparent, anything else paints over the blur
-        // 2. material "None" (Solid): the color is the users own pick in settings, accent or custom, theme independent
-        // 3. otherwise (Mica/Acrylic while Windows transparency is off): the flyout draws its own theme background
+        // 1. a backdrop controller is attached: root and bar stay transparent so the blur comes through, the graphs
+        //    area keeps its semi-transparent lift so the hierarchy survives on glass
+        // 2. material "None" (Solid): the root takes the users own pick from settings, accent or custom and theme
+        //    independent, the graphs area keeps the same lift on top of it
+        // 3. otherwise (Mica/Acrylic while Windows transparency is off): every surface is its own flat opaque color
+        //    and the graphs area carries no overlay at all
         //
-        // case 3 reads its brushes straight out of the App.xaml theme dictionary, so every hex value lives in exactly
-        // one place; the {ThemeResource} markup on FlyoutRootBorder is the first paint only, every later value is a
-        // local assignment from here and a local value permanently outranks the markup expression
+        // case 3 is deliberately alpha free: bar and content used to be coupled through that overlay, so correcting
+        // the base moved both at once and no measurement could be attributed to a single surface
+        // all colors come out of the App.xaml theme dictionary, so every hex value lives in exactly one place; the
+        // {ThemeResource} markup in the XAML is the first paint only, every later value is a local assignment from
+        // here and a local value permanently outranks the markup expression
         private void UpdateSolidBackground()
         {
             if (_isClosed || FlyoutRootBorder == null) return;
@@ -1156,9 +1161,14 @@ namespace FluentSensors.Features.TaskbarWidget
             var themeDictionary = (ResourceDictionary)Application.Current.Resources
                 .ThemeDictionaries[isLight ? "Light" : "Default"];
 
+            var transparent = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            var graphsOverlay = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutGraphsBackground"];
+
             if (_acrylicController != null)
             {
-                FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+                FlyoutRootBorder.Background = transparent;
+                FlyoutBottomBarBorder.Background = transparent;
+                GraphsContentGrid.Background = graphsOverlay;
             }
             else if (SettingsService.Instance.TaskbarBackdropType == "None")
             {
@@ -1167,13 +1177,19 @@ namespace FluentSensors.Features.TaskbarWidget
                     : SettingsService.Instance.TaskbarCustomTintColor;
 
                 FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(targetColor);
+                FlyoutBottomBarBorder.Background = transparent;
+                GraphsContentGrid.Background = graphsOverlay;
             }
             else
             {
                 FlyoutRootBorder.Background = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutWindowBackground"];
+                FlyoutBottomBarBorder.Background = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutBottomBarBackground"];
+                GraphsContentGrid.Background = transparent;
             }
 
+            // both strokes are solid in every mode, unlike the fills above
             FlyoutRootBorder.BorderBrush = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutWindowBorderBrush"];
+            FlyoutBottomBarBorder.BorderBrush = (Microsoft.UI.Xaml.Media.Brush)themeDictionary["FlyoutBottomBarSeparatorBrush"];
         }
 
         // applies the backdrop material for the current setting and the Windows transparency state

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -142,7 +142,7 @@ namespace FluentSensors.Features.TaskbarWidget
         public const int AnimationReferenceSensorCount = 2;
         public const double EnterDurationPerSensorFactor = 0.20; // scaling per sensor on open
         public const double ExitDurationPerSensorFactor = 0.14;  // scaling per sensor on close
-        public const double SlideDistancePerSensorFactor = 0.08; // scaling per sensor on the travelled distance
+        public const double SlideDistancePerSensorFactor = 0.10; // scaling per sensor on the travelled distance
 
         // keeps a single sensor from snapping open and a full height flyout from crawling
         public const double MinAnimationScaleFactor = 0.75;
@@ -1186,18 +1186,21 @@ namespace FluentSensors.Features.TaskbarWidget
             }
         }
 
+        // the bottom bar action lands on the sensor list with the taskbar profile active, because picking which
+        // sensors are pinned is the one thing the flyout itself cannot do
         private void BackToDashboard_Click(object sender, RoutedEventArgs e)
         {
             HideFlyout();
 
             if (MainWindow.CurrentInstance != null)
             {
-                MainWindow.CurrentInstance.OpenDashboard();
+                MainWindow.CurrentInstance.OpenSensorsForProfile(SensorSelectionProfile.Taskbar);
             }
             else
             {
                 var newMainWindow = new MainWindow();
                 newMainWindow.Activate();
+                newMainWindow.OpenSensorsForProfile(SensorSelectionProfile.Taskbar);
             }
         }
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -1,7 +1,6 @@
 using Microsoft.UI.Composition;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Dispatching;
-using Microsoft.UI.Input;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Hosting;
@@ -35,7 +34,7 @@ namespace FluentSensors.Features.TaskbarWidget
     // WinUI 3 has no built-in support for anchoring a borderless, non-activating window to an external Win32 shell
     // window; this window combines several low-level techniques:
     // 1. eliminates the non-client titlebar stripe via WM_NCCALCSIZE (0x0083) returning 0
-    // 2. supports asymmetric top-and-right resizing via InputNonClientPointerSource while locking bottom-left anchors in WM_SIZING (0x0214)
+    // 2. caps its own height against the work area and scrolls the graph list rather than growing past it
     // 3. places the window directly beneath Shell_TrayWnd in Z-order so it slides out from under the taskbar
     // 4. coordinates a physical window slide via DispatcherTimer with direct composition opacity fading
     // 5. applies dynamic DWM corner preferences and shadow suppression depending on the Windows transparency setting
@@ -130,11 +129,24 @@ namespace FluentSensors.Features.TaskbarWidget
         // --- animation & performance settings ---
 
         // physical window slide distance in DIP/pixels
-        public const int WindowSlideDistanceDip = 280;
+        public const int WindowSlideDistanceDip = 300;
 
         // animation duration in milliseconds
         public const int EnterAnimationDurationMs = 260; // duration on open (move-in)
         public const int ExitAnimationDurationMs = 140;  // duration on close (move-out)
+
+        // how far the two durations and the slide distance above follow the pinned sensor count: all three are
+        // tuned for AnimationReferenceSensorCount sensors, every sensor above or below scales them by their own factor
+        // these three are the knobs to turn; 0 pins a value to its base, 0.18 makes a three sensor flyout 18 percent
+        // slower than a two sensor one
+        public const int AnimationReferenceSensorCount = 2;
+        public const double EnterDurationPerSensorFactor = 0.20; // scaling per sensor on open
+        public const double ExitDurationPerSensorFactor = 0.14;  // scaling per sensor on close
+        public const double SlideDistancePerSensorFactor = 0.08; // scaling per sensor on the travelled distance
+
+        // keeps a single sensor from snapping open and a full height flyout from crawling
+        public const double MinAnimationScaleFactor = 0.75;
+        public const double MaxAnimationScaleFactor = 3.0;
 
         // fade opacity (1.0f = no fade, 0.0f = full fade)
         public const float EnterFadeStartOpacity = 0.9f; // initial opacity when opening
@@ -174,27 +186,29 @@ namespace FluentSensors.Features.TaskbarWidget
         private const string WindowKey = "TaskbarFlyout";
 
         // Anchor offsets configurable in code-behind
+        // the taskbar gap doubles as the gap to the top of the work area, and that pair is what caps the window
+        // height, see PositionAboveTaskbar
         public const int FlyoutMarginToTaskbarDip = 12; // vertical gap between taskbar top and flyout bottom edge
-        public const int FlyoutMarginToScreenEdgeDip = 10; // smallest gap the flyout keeps to the left, right and top screen edges
+        public const int FlyoutMarginToScreenEdgeDip = 12; // smallest gap the flyout keeps to the left and right screen edges
 
         // horizontal offset from the aligned edge, meaning depends on TaskbarFlyoutAlignment:
         // Left = pixels to move right (inward from the widget left edge)
         // Right = pixels to move left (inward from the widget right edge)
         // Center = unused
-        public const int FlyoutHorizontalOffsetDip = 2;
+        public const int FlyoutHorizontalOffsetDip = 0;
 
-        // default and minimum width in DIP (matching standard WidgetWindow width)
+        // fixed width in DIP (matching standard WidgetWindow width)
         public const int FlyoutDefaultWidthDip = 250;
-        public const int MinFlyoutWidthFloorDip = 250;
 
-        // default and minimum height per graph slot in DIP
+        // height of a single graph slot in DIP
         public const int FlyoutDefaultGraphHeightDip = 100;
-        public const int MinFlyoutGraphHeightDip = 100;
 
         // --- flyout layout ---
 
         // the two knobs for the interior; every visible inset inside the window comes from one of them
-        public static readonly Thickness FlyoutGraphsPadding = new Thickness(6, 9, 6, 7);
+        // the graphs inset is a margin on the list rather than padding on the surface below it, so the scroll region
+        // stays the full width of the window and the scrollbar rides its edge instead of sitting 6px inside
+        public static readonly Thickness FlyoutGraphsMargin = new Thickness(6, 9, 6, 7);
         public static readonly Thickness FlyoutBottomBarPadding = new Thickness(0, 0, 0, 0);
 
         // gap between two stacked graphs
@@ -219,11 +233,19 @@ namespace FluentSensors.Features.TaskbarWidget
         private UISettings? _uiSettings;
 
         private int _bottomAnchorY;
-        private int _leftAnchorX;
         private int _targetX;
         private int _targetY;
         private bool _isAdjustingPosition;
         private bool _isHiding;
+
+        // sensor count the slide durations are scaled by; capped at what still fits once the window reaches its
+        // height cap, because past that point the window stops growing
+        private int _animationSensorCount = AnimationReferenceSensorCount;
+
+        // the graph rows sit in an ItemsPanelTemplate and cannot be named in XAML, so the panel is cached the first
+        // time a layout pass produces it; _isGraphsScrolling holds the mode until then
+        private FluentSensors.Controls.VerticalStretchPanel? _graphsPanel;
+        private bool _isGraphsScrolling;
 
         // native window animation timer
         private DispatcherTimer? _animTimer;
@@ -260,7 +282,7 @@ namespace FluentSensors.Features.TaskbarWidget
             presenter.IsAlwaysOnTop = false; // do not force topmost above taskbar shell
             presenter.IsMaximizable = false;
             presenter.IsMinimizable = false;
-            presenter.IsResizable = false; // resize is handled via InputNonClientPointerSource, keeping WS_THICKFRAME off
+            presenter.IsResizable = false; // the height is always derived from the pinned sensor count, never dragged
             _appWindow.SetPresenter(presenter);
 
             // remove WS_THICKFRAME and WS_CAPTION and apply WS_POPUP and WS_EX_TOOLWINDOW
@@ -283,9 +305,7 @@ namespace FluentSensors.Features.TaskbarWidget
 
             // hook win32 messages:
             // 1. WM_NCCALCSIZE (0x0083): eliminates the 8px non-client white titlebar stripe completely
-            // 2. WM_SIZING (0x0214): locks the Bottom-Left anchor coordinates during resizing
-            // 3. WM_EXITSIZEMOVE (0x0232): saves window size when resize ends
-            // 4. WM_SYSCOMMAND (0x0112): prevents dragging/moving the window
+            // 2. WM_SYSCOMMAND (0x0112): prevents dragging/moving the window
             _messageMonitor = new WindowMessageMonitor(_hwnd);
             _messageMonitor.WindowMessageReceived += OnWindowMessageReceived;
 
@@ -315,7 +335,7 @@ namespace FluentSensors.Features.TaskbarWidget
             };
 
             // the interior is driven entirely from the layout metrics above, the XAML carries no numbers of its own
-            GraphsContentGrid.Padding = FlyoutGraphsPadding;
+            GraphsItemsControl.Margin = FlyoutGraphsMargin;
             BottomBarContentGrid.Padding = FlyoutBottomBarPadding;
             GraphsItemsControl.LayoutUpdated += OnGraphsItemsControlLayoutUpdated;
 
@@ -335,14 +355,21 @@ namespace FluentSensors.Features.TaskbarWidget
             try
             {
                 _uiSettings = new UISettings();
-                _uiSettings.AdvancedEffectsEnabledChanged += (s, e) => ScheduleRecreation();
-                _uiSettings.ColorValuesChanged += (s, e) => ScheduleRecreation();
+                _uiSettings.AdvancedEffectsEnabledChanged += OnSystemVisualSettingsChanged;
+                _uiSettings.ColorValuesChanged += OnSystemVisualSettingsChanged;
                 UpdateShadowPolicy();
             }
             catch
             {
                 // safety guard if UISettings is unavailable
             }
+        }
+
+        // a named handler rather than a lambda, so SafeDestroy can detach it again; every rebuilt window subscribes
+        // anew and without the detach the UISettings handler list grows by one per rebuild
+        private void OnSystemVisualSettingsChanged(UISettings sender, object args)
+        {
+            ScheduleRecreation();
         }
 
         private void UpdateShadowPolicy()
@@ -383,37 +410,6 @@ namespace FluentSensors.Features.TaskbarWidget
         }
 
 
-        // === non-client resize regions (Top and Right only) ===
-
-        private void UpdateNonClientResizeRegions()
-        {
-            try
-            {
-                var nonClientInput = InputNonClientPointerSource.GetForWindowId(_appWindow.Id);
-                if (nonClientInput == null) return;
-
-                int width = _appWindow.Size.Width;
-                int height = _appWindow.Size.Height;
-                int border = (int)Math.Round(10 * GetScaleFactor());
-
-                // Top border extending full width (including top-right corner)
-                var topRect = new RectInt32(0, 0, width, border);
-                // Right border extending full height (including top-right corner)
-                var rightRect = new RectInt32(Math.Max(0, width - border), 0, border, height);
-
-                nonClientInput.SetRegionRects(NonClientRegionKind.TopBorder, new[] { topRect });
-                nonClientInput.SetRegionRects(NonClientRegionKind.RightBorder, new[] { rightRect });
-
-                nonClientInput.ClearRegionRects(NonClientRegionKind.LeftBorder);
-                nonClientInput.ClearRegionRects(NonClientRegionKind.BottomBorder);
-            }
-            catch
-            {
-                // safety guard if platform version does not support InputNonClientPointerSource
-            }
-        }
-
-
         // === win32 message handling ===
 
         private void OnWindowMessageReceived(object? sender, WindowMessageEventArgs e)
@@ -426,41 +422,6 @@ namespace FluentSensors.Features.TaskbarWidget
                     e.Result = IntPtr.Zero;
                     e.Handled = true;
                 }
-            }
-            else if (e.Message.MessageId == 0x0214) // WM_SIZING
-            {
-                var rect = Marshal.PtrToStructure<NativeMethods.RECT>(e.Message.LParam);
-                double scale = GetScaleFactor();
-
-                // lock bottom and left anchors
-                if (_bottomAnchorY > 0)
-                {
-                    rect.Bottom = _bottomAnchorY;
-                    rect.Left = _leftAnchorX;
-                }
-
-                // enforce minimum width and height constraints
-                int minW = (int)Math.Round(MinFlyoutWidthFloorDip * scale);
-                int minH = CalculateFlyoutMinHeight(ViewModel.PinnedSensors.Count, scale);
-
-                if (rect.Right - rect.Left < minW)
-                {
-                    rect.Right = rect.Left + minW;
-                }
-                if (rect.Bottom - rect.Top < minH)
-                {
-                    rect.Top = rect.Bottom - minH;
-                }
-
-                Marshal.StructureToPtr(rect, e.Message.LParam, false);
-                e.Result = (IntPtr)1; // TRUE
-                e.Handled = true;
-            }
-            else if (e.Message.MessageId == 0x0232) // WM_EXITSIZEMOVE
-            {
-                UpdateNonClientResizeRegions();
-                UpdateShadowPolicy();
-                SaveWindowState();
             }
             else if (e.Message.MessageId == 0x0112) // WM_SYSCOMMAND
             {
@@ -475,17 +436,9 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // === public methods ===
 
-        // resets saved flyout dimensions so the size is cleanly recalculated on next open / button click
+        // recalculates the flyout geometry so the next open reflects the current pinned sensor count
         public static void ResetGeometry()
         {
-            var state = WindowStateService.Instance.GetState(WindowKey);
-            if (state != null)
-            {
-                state.Width = 0;
-                state.Height = 0;
-                WindowStateService.Instance.SetState(WindowKey, state);
-            }
-
             if (CurrentInstance != null && TaskbarWidgetWindow.CurrentInstance != null)
             {
                 CurrentInstance.PositionAboveTaskbar(TaskbarWidgetWindow.CurrentInstance, startForSlideAnimation: false);
@@ -623,6 +576,17 @@ namespace FluentSensors.Features.TaskbarWidget
             }
             catch { }
 
+            try
+            {
+                if (_uiSettings != null)
+                {
+                    _uiSettings.AdvancedEffectsEnabledChanged -= OnSystemVisualSettingsChanged;
+                    _uiSettings.ColorValuesChanged -= OnSystemVisualSettingsChanged;
+                    _uiSettings = null;
+                }
+            }
+            catch { }
+
             // AppWindow_Closing cancels the close and re-registers this instance as _retainedInstance; detaching it
             // here is what lets the Close below go through instead of resurrecting a window that is already torn down
             try
@@ -650,9 +614,10 @@ namespace FluentSensors.Features.TaskbarWidget
         // --- workaround: window recreation on global OS theme/transparency change ---
         // problem: the exact underlying reason why Windows DWM fails to bind DesktopAcrylicController blur properly
         // without a complete window recreation is not fully clear and is based purely on empirical observation
-        // fix: upon receiving a global theme or transparency change from Windows, both windows (TaskbarFlyoutWindow
-        // and WidgetWindow, if open) are fully destroyed and rebuilt; each rebuilt window then kicks its own backdrop
-        // from its constructor via KickBackdropRefresh, which goes through SetBackdrop parameters only
+        // fix: upon receiving a global theme or transparency change from Windows, all three windows
+        // (TaskbarFlyoutWindow, WidgetWindow and TaskbarWidgetWindow, each if open) are fully destroyed and rebuilt;
+        // each rebuilt window then kicks its own backdrop from its constructor via KickBackdropRefresh, which goes
+        // through SetBackdrop parameters only
         //
         // only ever driven by the Windows-level UISettings events; an in-app theme switch must not land here, and a
         // persisted SettingsService property must never be toggled to force a repaint: every setter snapshots the whole
@@ -686,14 +651,13 @@ namespace FluentSensors.Features.TaskbarWidget
             });
         }
 
-        // tears both flyout instances down for real and builds a fresh one, the destructive half of the workaround
-        // documented on ScheduleRecreation above
+        // tears both flyout instances down for real and rebuilds all three windows, the destructive half of the
+        // workaround documented on ScheduleRecreation above
         //
-        // the only caller of SafeDestroy; the widget window is rebuilt in between on purpose, the flyout anchors its
-        // geometry to it and needs the new one to already exist
+        // the only caller of SafeDestroy; the flyout goes first and comes back last, because it anchors its geometry
+        // to the taskbar widget and the new widget has to sit on the taskbar before the new flyout can be placed
         private static void ExecuteFullRebuild()
         {
-            var widgetWindow = TaskbarWidgetWindow.CurrentInstance;
             bool flyoutWasVisible = CurrentInstance != null && CurrentInstance._appWindow != null && CurrentInstance._appWindow.IsVisible;
 
             // 1. Safely destroy existing TaskbarFlyoutWindow instances
@@ -714,21 +678,9 @@ namespace FluentSensors.Features.TaskbarWidget
             // 2. Safely destroy and rebuild WidgetWindow if open
             WidgetWindow.RecreateWindow();
 
-            // 3. Rebuild TaskbarFlyoutWindow
-            if (widgetWindow != null)
-            {
-                widgetWindow.DispatcherQueue.TryEnqueue(() =>
-                {
-                    if (flyoutWasVisible)
-                    {
-                        ShowFlyout(widgetWindow);
-                    }
-                    else
-                    {
-                        Preload(widgetWindow);
-                    }
-                });
-            }
+            // 3. Safely destroy and rebuild TaskbarWidgetWindow; the rebuilt widget brings the flyout back itself
+            // from the end of its embedding step, see TaskbarWidgetWindow.RecreateWindow
+            TaskbarWidgetWindow.RecreateWindow(restoreFlyout: flyoutWasVisible);
         }
 
 
@@ -738,32 +690,58 @@ namespace FluentSensors.Features.TaskbarWidget
         {
             TaskbarWidgetWindow.CurrentInstance?.SetFlyoutActive(true);
 
+            int durationMs = ScaleAnimationDuration(EnterAnimationDurationMs, EnterDurationPerSensorFactor);
+
             // 1. Content Fade (DirectComposition)
-            PlayContentFade(EnterFadeStartOpacity, EnterFadeEndOpacity, EnterAnimationDurationMs);
+            PlayContentFade(EnterFadeStartOpacity, EnterFadeEndOpacity, durationMs);
 
             // 2. Physical Window Slide Up
-            int slideDistPx = (int)Math.Round(WindowSlideDistanceDip * GetScaleFactor());
+            int slideDistPx = GetSlideDistancePx(GetScaleFactor());
             int startY = _targetY + slideDistPx;
 
             EnsureBehindTaskbarZOrder();
-            AnimateNativeWindowPosition(_targetX, startY, _targetX, _targetY, EnterAnimationDurationMs, isEntering: true);
+            AnimateNativeWindowPosition(_targetX, startY, _targetX, _targetY, durationMs, isEntering: true);
         }
 
         private void SlideOutToBottom(Action onCompleted)
         {
             TaskbarWidgetWindow.CurrentInstance?.SetFlyoutActive(false);
 
+            int durationMs = ScaleAnimationDuration(ExitAnimationDurationMs, ExitDurationPerSensorFactor);
+
             // 1. Content Fade (DirectComposition)
-            PlayContentFade(1.0f, ExitFadeEndOpacity, ExitAnimationDurationMs);
+            PlayContentFade(1.0f, ExitFadeEndOpacity, durationMs);
 
             // 2. Physical Window Slide Down
-            int slideDistPx = (int)Math.Round(WindowSlideDistanceDip * GetScaleFactor());
+            int slideDistPx = GetSlideDistancePx(GetScaleFactor());
             int currentX = _appWindow.Position.X;
             int currentY = _appWindow.Position.Y;
             int endY = _targetY + slideDistPx;
 
             EnsureBehindTaskbarZOrder();
-            AnimateNativeWindowPosition(currentX, currentY, currentX, endY, ExitAnimationDurationMs, isEntering: false, onComplete: onCompleted);
+            AnimateNativeWindowPosition(currentX, currentY, currentX, endY, durationMs, isEntering: false, onComplete: onCompleted);
+        }
+
+        // the shared scaling law: how far a value moves from its base with the number of graph rows the flyout is
+        // showing, so a tall window does not open in the time a two row one does
+        private double AnimationScaleFactor(double perSensorFactor)
+        {
+            double factor = 1.0 + ((_animationSensorCount - AnimationReferenceSensorCount) * perSensorFactor);
+
+            return Math.Clamp(factor, MinAnimationScaleFactor, MaxAnimationScaleFactor);
+        }
+
+        private int ScaleAnimationDuration(int baseDurationMs, double perSensorFactor)
+        {
+            return (int)Math.Round(baseDurationMs * AnimationScaleFactor(perSensorFactor));
+        }
+
+        // the distance both slides travel, in physical pixels
+        // PositionAboveTaskbar parks the window on the same value before the enter slide, so it has to come from here
+        // rather than from WindowSlideDistanceDip directly
+        private int GetSlideDistancePx(double scaleFactor)
+        {
+            return (int)Math.Round(WindowSlideDistanceDip * AnimationScaleFactor(SlideDistancePerSensorFactor) * scaleFactor);
         }
 
         private void PlayContentFade(float fromOpacity, float toOpacity, int durationMs)
@@ -841,37 +819,10 @@ namespace FluentSensors.Features.TaskbarWidget
             var primaryTaskbar = WinTaskbarService.Instance.DiscoverNow().FirstOrDefault();
             double scale = primaryTaskbar != null ? (primaryTaskbar.Dpi / 96.0) : GetScaleFactor();
 
-            var savedState = WindowStateService.Instance.GetState(WindowKey);
-
-            // width is fixed to 310 DIP (matching standard WidgetWindow width)
-            int defaultWidthPx = (int)Math.Round(FlyoutDefaultWidthDip * scale);
-            int minWidthPx = defaultWidthPx;
+            // width is fixed to FlyoutDefaultWidthDip (matching standard WidgetWindow width)
+            int desiredWidthPx = (int)Math.Round(FlyoutDefaultWidthDip * scale);
 
             int sensorCount = ViewModel.PinnedSensors.Count;
-
-            // enforce resize constraints: min-width is 310 DIP, min-height is the compact sensor height
-            int minHeightDip = (int)Math.Round(CalculateFlyoutMinHeight(sensorCount, scale) / scale);
-            var manager = WindowManager.Get(this);
-            manager.MinWidth = MinFlyoutWidthFloorDip;
-            manager.MinHeight = minHeightDip;
-
-            int minHeightPx = (int)Math.Round(minHeightDip * scale);
-            int defaultHeightPx = CalculateFlyoutDefaultHeight(sensorCount, scale);
-
-            int desiredWidthPx;
-            int desiredHeightPx;
-
-            if (savedState != null && savedState.Width > 0 && savedState.Height > 0)
-            {
-                desiredWidthPx = Math.Max(savedState.Width, minWidthPx);
-                desiredHeightPx = Math.Max(savedState.Height, minHeightPx);
-            }
-            else
-            {
-                // reset to exact default geometry
-                desiredWidthPx = defaultWidthPx;
-                desiredHeightPx = defaultHeightPx;
-            }
 
             // vertical gap above the taskbar, horizontal placement over the widget per TaskbarFlyoutAlignment
             int marginPx = (int)Math.Round(FlyoutMarginToTaskbarDip * scale);
@@ -879,6 +830,26 @@ namespace FluentSensors.Features.TaskbarWidget
             int edgeMarginPx = (int)Math.Round(FlyoutMarginToScreenEdgeDip * scale);
 
             _bottomAnchorY = primaryTaskbar != null ? (primaryTaskbar.Rect.Y - marginPx) : (widgetRect.Top - marginPx);
+
+            // the gap that holds the flyout off the taskbar is also the gap it keeps to the top of the work area, and
+            // that pair caps the height; without the cap enough pinned sensors produce a window taller than the screen
+            // whose bottom edge ends up behind the taskbar
+            // one graph slot is the floor, so a taskbar on a very short work area cannot produce a zero height window
+            var workArea = DisplayArea.Primary.WorkArea;
+            int maxHeightPx = Math.Max(
+                CalculateFlyoutDefaultHeight(1, scale),
+                _bottomAnchorY - (workArea.Y + marginPx));
+
+            int desiredHeightPx = CalculateFlyoutDefaultHeight(sensorCount, scale);
+            bool isScrolling = desiredHeightPx > maxHeightPx;
+            if (isScrolling)
+            {
+                desiredHeightPx = maxHeightPx;
+            }
+
+            // once capped the window stops growing, so the slide durations stop growing with it too
+            _animationSensorCount = isScrolling ? CountFittingGraphSlots(maxHeightPx, scale) : sensorCount;
+            ApplyGraphsScrollMode(isScrolling);
 
             // Left/Right anchor to the matching widget edge and let the offset pull the flyout inward;
             // Center ignores the offset and lines the flyout center up with the widget center
@@ -890,30 +861,21 @@ namespace FluentSensors.Features.TaskbarWidget
             };
             _targetY = _bottomAnchorY - desiredHeightPx;
 
-            // clamp within the primary work area, never closer than edgeMarginPx to a left, right or top edge;
+            // clamp within the primary work area, never closer than edgeMarginPx to a left or right screen edge;
             // the left edge wins when the screen is too narrow to honor both sides at once
-            var workArea = DisplayArea.Primary.WorkArea;
+            // the top needs no clamp of its own, the height cap above already lands _targetY on marginPx
             int rightLimitX = workArea.X + workArea.Width - desiredWidthPx - edgeMarginPx;
             int leftLimitX = workArea.X + edgeMarginPx;
             _targetX = Math.Max(leftLimitX, Math.Min(_targetX, rightLimitX));
 
-            if (_targetY < workArea.Y + edgeMarginPx)
-            {
-                _targetY = workArea.Y + edgeMarginPx;
-            }
-
-            // the WM_SIZING resize path locks the window left edge to this, so it has to be the clamped value
-            _leftAnchorX = _targetX;
-
             int initialY = startForSlideAnimation
-                ? (_targetY + (int)Math.Round(WindowSlideDistanceDip * scale))
+                ? (_targetY + GetSlideDistancePx(scale))
                 : _targetY;
 
             _isAdjustingPosition = true;
             _appWindow.MoveAndResize(new RectInt32(_targetX, initialY, desiredWidthPx, desiredHeightPx));
             _isAdjustingPosition = false;
 
-            UpdateNonClientResizeRegions();
             UpdateShadowPolicy();
         }
 
@@ -923,14 +885,21 @@ namespace FluentSensors.Features.TaskbarWidget
             return dpi / 96.0;
         }
 
-        private int CalculateFlyoutMinHeight(int sensorCount, double scaleFactor)
-        {
-            return (int)(CalculateFlyoutContentHeight(sensorCount, MinFlyoutGraphHeightDip) * scaleFactor);
-        }
-
         private int CalculateFlyoutDefaultHeight(int sensorCount, double scaleFactor)
         {
             return (int)(CalculateFlyoutContentHeight(sensorCount, FlyoutDefaultGraphHeightDip) * scaleFactor);
+        }
+
+        // how many graph slots still fit inside a capped window height, at the standard slot height
+        private static int CountFittingGraphSlots(int maxHeightPx, double scaleFactor)
+        {
+            double interiorDip = (maxHeightPx / scaleFactor) - FlyoutBottomBarHeightDip
+                - FlyoutGraphsMargin.Top - FlyoutGraphsMargin.Bottom;
+
+            int slots = (int)Math.Floor(
+                (interiorDip + FlyoutGraphSpacingDip) / (FlyoutDefaultGraphHeightDip + FlyoutGraphSpacingDip));
+
+            return Math.Max(1, slots);
         }
 
         // window height for n graph slots: the bar strip, the graphs padding, n slots and the n-1 gaps between them
@@ -939,7 +908,7 @@ namespace FluentSensors.Features.TaskbarWidget
             if (sensorCount <= 0) return FlyoutBottomBarHeightDip;
 
             return FlyoutBottomBarHeightDip
-                + FlyoutGraphsPadding.Top + FlyoutGraphsPadding.Bottom
+                + FlyoutGraphsMargin.Top + FlyoutGraphsMargin.Bottom
                 + (sensorCount * graphHeightDip)
                 + ((sensorCount - 1) * FlyoutGraphSpacingDip);
         }
@@ -950,7 +919,6 @@ namespace FluentSensors.Features.TaskbarWidget
 
             if (args.DidSizeChange && _bottomAnchorY > 0)
             {
-                UpdateNonClientResizeRegions();
                 UpdateShadowPolicy();
                 SaveWindowState();
             }
@@ -967,22 +935,51 @@ namespace FluentSensors.Features.TaskbarWidget
             var state = WindowStateService.Instance.GetState(WindowKey) ?? new Persistence.Models.WindowState();
             state.X = _appWindow.Position.X;
             state.Y = _appWindow.Position.Y;
-            state.Width = _appWindow.Size.Width;
-            state.Height = _appWindow.Size.Height;
-            state.SensorCount = ViewModel.PinnedSensors.Count;
             state.WasOpen = false;
+
+            // the size is no longer persisted at all, it is derived from the pinned sensor count and the height cap
+            // on every open; clearing it here drops whatever a resizable flyout left behind
+            state.Width = 0;
+            state.Height = 0;
 
             WindowStateService.Instance.SetState(WindowKey, state);
         }
 
-        // the graph panel sits inside an ItemsPanelTemplate and cannot be named, so FlyoutGraphSpacingDip is
-        // pushed onto it from here; the items host only exists after the first layout pass, hence the retry
+        // the graph panel sits inside an ItemsPanelTemplate and cannot be named, so FlyoutGraphSpacingDip and the
+        // scroll mode are pushed onto it from here; the items host only exists after the first layout pass, hence
+        // the retry
         private void OnGraphsItemsControlLayoutUpdated(object? sender, object e)
         {
             if (GraphsItemsControl.ItemsPanelRoot is FluentSensors.Controls.VerticalStretchPanel panel)
             {
+                _graphsPanel = panel;
                 panel.Spacing = FlyoutGraphSpacingDip;
+                ApplyGraphsScrollMode(_isGraphsScrolling);
                 GraphsItemsControl.LayoutUpdated -= OnGraphsItemsControlLayoutUpdated;
+            }
+        }
+
+        // switches the graph list between filling the window and stacking at the standard slot height inside a scroll
+        // region; the fixed height is what the panel needs there, a ScrollViewer measures with infinite height and an
+        // equal split has nothing to divide
+        //
+        // two explicit modes rather than one permanently scrolling viewer, so a rounding difference of a single pixel
+        // cannot put a scrollbar on a window that fits
+        private void ApplyGraphsScrollMode(bool isScrolling)
+        {
+            _isGraphsScrolling = isScrolling;
+
+            if (GraphsScrollViewer != null)
+            {
+                GraphsScrollViewer.VerticalScrollMode = isScrolling ? ScrollMode.Enabled : ScrollMode.Disabled;
+                GraphsScrollViewer.VerticalScrollBarVisibility = isScrolling
+                    ? ScrollBarVisibility.Auto
+                    : ScrollBarVisibility.Disabled;
+            }
+
+            if (_graphsPanel != null)
+            {
+                _graphsPanel.FixedItemHeight = isScrolling ? FlyoutDefaultGraphHeightDip : 0;
             }
         }
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -149,15 +149,15 @@ namespace FluentSensors.Features.TaskbarWidget
         public static readonly Thickness FlyoutGraphsPadding = new Thickness(4.5, 1, 4.5, 6);
 
         // --- Mica Flyout Blur Preset Settings (used when BackdropType == "Mica" and Transparency is ON) ---
-        // Dark Mode Preset (#292929, Luminosity 0.90, Tint 0.70):
-        public static readonly Windows.UI.Color MicaPresetDarkTintColor = Windows.UI.Color.FromArgb(255, 0x29, 0x29, 0x29);
-        public const float MicaPresetDarkLuminosity = 0.90f;
-        public const float MicaPresetDarkTintOpacity = 0.70f;
+        // Dark Mode Preset (Target #222222 on-screen):
+        public static readonly Windows.UI.Color MicaPresetDarkTintColor = Windows.UI.Color.FromArgb(255, 0x1A, 0x1A, 0x1A);
+        public const float MicaPresetDarkLuminosity = 0.0f;
+        public const float MicaPresetDarkTintOpacity = 0.85f;
 
-        // Light Mode Preset (#F2F2F2, Luminosity 0.90, Tint 0.60):
+        // Light Mode Preset (Target #F2F2F2 on-screen):
         public static readonly Windows.UI.Color MicaPresetLightTintColor = Windows.UI.Color.FromArgb(255, 0xF2, 0xF2, 0xF2);
         public const float MicaPresetLightLuminosity = 0.90f;
-        public const float MicaPresetLightTintOpacity = 0.60f;
+        public const float MicaPresetLightTintOpacity = 0.70f;
 
 
         // === fields ===
@@ -175,7 +175,7 @@ namespace FluentSensors.Features.TaskbarWidget
         // default and minimum height per graph slot in DIP
         public const int FlyoutDefaultGraphHeightDip = 100;
         public const int MinFlyoutGraphHeightDip = 90;
-        public const int FlyoutHeaderHeightDip = 31;
+        public const int FlyoutBottomBarHeightDip = 48; // bottom action bar strip; fixed height added on top of the graph slots in the window height math
         public const int FlyoutGraphSpacingDip = 8;
 
         private AppWindow _appWindow;
@@ -211,6 +211,7 @@ namespace FluentSensors.Features.TaskbarWidget
         public TaskbarFlyoutWindow(TaskbarWidgetViewModel viewModel)
         {
             ViewModel = viewModel;
+            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === Constructor ENTER. HashCode={this.GetHashCode()} AppTheme={SettingsService.Instance.AppTheme} Backdrop={SettingsService.Instance.TaskbarBackdropType}");
             this.InitializeComponent();
             CurrentInstance = this;
 
@@ -254,6 +255,9 @@ namespace FluentSensors.Features.TaskbarWidget
             _messageMonitor = new WindowMessageMonitor(_hwnd);
             _messageMonitor.WindowMessageReceived += OnWindowMessageReceived;
 
+            // initialize shadow policy & UISettings based on Windows transparency setting
+            InitializeShadowPolicy();
+
             // theming & backdrop (Taskbar ecosystem)
             SetBackdrop(SettingsService.Instance.TaskbarBackdropType);
             ApplyTheme(SettingsService.Instance.AppTheme);
@@ -265,11 +269,15 @@ namespace FluentSensors.Features.TaskbarWidget
 
             ((FrameworkElement)this.Content).ActualThemeChanged += (s, e) =>
             {
-                this.DispatcherQueue.TryEnqueue(UpdateSolidBackground);
+                if (_isClosed) return;
+                this.DispatcherQueue.TryEnqueue(() =>
+                {
+                    if (_isClosed) return;
+                    SetConfigurationSourceTheme();
+                    UpdateAcrylicProperties();
+                    UpdateSolidBackground();
+                });
             };
-
-            // initialize shadow policy based on Windows transparency setting
-            InitializeShadowPolicy();
 
             // apply configurable paddings
             RootGrid.Padding = FlyoutRootPadding;
@@ -494,9 +502,11 @@ namespace FluentSensors.Features.TaskbarWidget
         public static void ShowFlyout(TaskbarWidgetWindow widgetWindow)
         {
             if (widgetWindow == null) return;
+            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === ShowFlyout: CurrentInstance={(CurrentInstance != null ? CurrentInstance.GetHashCode() : 0)}, Retained={(_retainedInstance != null ? _retainedInstance.GetHashCode() : 0)}, AppTheme={SettingsService.Instance.AppTheme}");
 
             if (CurrentInstance != null)
             {
+                CurrentInstance.ApplyTheme(SettingsService.Instance.AppTheme);
                 CurrentInstance.PositionAboveTaskbar(widgetWindow, startForSlideAnimation: true);
                 CurrentInstance.SetGraphsRenderingActive(true);
                 CurrentInstance._appWindow.Show();
@@ -512,6 +522,7 @@ namespace FluentSensors.Features.TaskbarWidget
                 _retainedInstance = null;
                 CurrentInstance = window;
 
+                window.ApplyTheme(SettingsService.Instance.AppTheme);
                 window.PositionAboveTaskbar(widgetWindow, startForSlideAnimation: true);
                 window.SetGraphsRenderingActive(true);
                 window._appWindow.Show();
@@ -522,6 +533,7 @@ namespace FluentSensors.Features.TaskbarWidget
             }
 
             var newWindow = new TaskbarFlyoutWindow(widgetWindow.ViewModel);
+            newWindow.ApplyTheme(SettingsService.Instance.AppTheme);
             newWindow.PositionAboveTaskbar(widgetWindow, startForSlideAnimation: true);
             newWindow.SetGraphsRenderingActive(true);
             newWindow._appWindow.Show();
@@ -585,6 +597,7 @@ namespace FluentSensors.Features.TaskbarWidget
         // setting is briefly toggled to None (Solid) and immediately back to Mica to force a full DWM compositor refresh
         public static void ScheduleRecreation()
         {
+            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === ScheduleRecreation called.");
             var queue = TaskbarWidgetWindow.CurrentInstance?.DispatcherQueue
                 ?? MainWindow.CurrentInstance?.DispatcherQueue
                 ?? DispatcherQueue.GetForCurrentThread();
@@ -614,6 +627,7 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private static void ExecuteFullRebuild()
         {
+            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === ExecuteFullRebuild called.");
             var widgetWindow = TaskbarWidgetWindow.CurrentInstance;
             bool flyoutWasVisible = CurrentInstance != null && CurrentInstance._appWindow != null && CurrentInstance._appWindow.IsVisible;
 
@@ -857,13 +871,13 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private int CalculateFlyoutMinHeight(int sensorCount, double scaleFactor)
         {
-            double minXamlHeight = FlyoutHeaderHeightDip + (sensorCount * (MinFlyoutGraphHeightDip + FlyoutGraphSpacingDip));
+            double minXamlHeight = FlyoutBottomBarHeightDip + (sensorCount * (MinFlyoutGraphHeightDip + FlyoutGraphSpacingDip));
             return (int)(minXamlHeight * scaleFactor);
         }
 
         private int CalculateFlyoutDefaultHeight(int sensorCount, double scaleFactor)
         {
-            double defaultXamlHeight = FlyoutHeaderHeightDip + (sensorCount * (FlyoutDefaultGraphHeightDip + FlyoutGraphSpacingDip));
+            double defaultXamlHeight = FlyoutBottomBarHeightDip + (sensorCount * (FlyoutDefaultGraphHeightDip + FlyoutGraphSpacingDip));
             return (int)(defaultXamlHeight * scaleFactor);
         }
 
@@ -977,7 +991,13 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private void OnThemeChanged(string newTheme)
         {
-            this.DispatcherQueue.TryEnqueue(() => ApplyTheme(newTheme));
+            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === OnThemeChanged ENTER: newTheme={newTheme}, HashCode={this.GetHashCode()}");
+            this.DispatcherQueue.TryEnqueue(() =>
+            {
+                ApplyTheme(newTheme);
+                UpdateSolidBackground();
+                ScheduleRecreation();
+            });
         }
 
         private void OnBackdropTypeChanged(string newType)
@@ -1002,6 +1022,7 @@ namespace FluentSensors.Features.TaskbarWidget
         private void ApplyTheme(string themeTag)
         {
             if (_isClosed) return;
+            System.Diagnostics.Debug.WriteLine($"[FlyoutDebug] === ApplyTheme ENTER: themeTag={themeTag}, HashCode={this.GetHashCode()}");
 
             var elementTheme = themeTag switch
             {
@@ -1035,13 +1056,31 @@ namespace FluentSensors.Features.TaskbarWidget
             }
         }
 
+        private bool IsCurrentThemeLight()
+        {
+            if (_isClosed) return false;
+
+            string themeTag = SettingsService.Instance.AppTheme;
+            if (themeTag == "Light") return true;
+            if (themeTag == "Dark") return false;
+
+            try
+            {
+                return this.Content is FrameworkElement fe && fe.ActualTheme == ElementTheme.Light;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         private void UpdateAcrylicProperties()
         {
             if (_isClosed) return;
 
             if (_acrylicController != null)
             {
-                bool isLight = this.Content is FrameworkElement fe && fe.ActualTheme == ElementTheme.Light;
+                bool isLight = IsCurrentThemeLight();
                 string backdropType = SettingsService.Instance.TaskbarBackdropType;
 
                 if (backdropType == "Mica")
@@ -1065,9 +1104,10 @@ namespace FluentSensors.Features.TaskbarWidget
                 else
                 {
                     // "Acrylic" uses user-configured settings sliders
+                    // fallback tint when no accent/custom color applies: #F2F2F2 Light, #222222 Dark (matches the opaque path)
                     Windows.UI.Color defaultTint = isLight
-                        ? Windows.UI.Color.FromArgb(255, 0xF9, 0xF9, 0xF9)
-                        : Windows.UI.Color.FromArgb(255, 0x20, 0x20, 0x20);
+                        ? Windows.UI.Color.FromArgb(255, 0xF2, 0xF2, 0xF2)
+                        : Windows.UI.Color.FromArgb(255, 0x22, 0x22, 0x22);
 
                     Windows.UI.Color targetColor = SettingsService.Instance.TaskbarUseAccentColor
                         ? (Windows.UI.Color)Application.Current.Resources["SystemAccentColor"]
@@ -1085,10 +1125,10 @@ namespace FluentSensors.Features.TaskbarWidget
         {
             if (_isClosed || FlyoutRootBorder == null) return;
 
-            bool isLight = this.Content is FrameworkElement fe && fe.ActualTheme == ElementTheme.Light;
+            bool isLight = IsCurrentThemeLight();
             string backdropType = SettingsService.Instance.TaskbarBackdropType;
 
-            if (backdropType == "None")
+            if (backdropType == "None" && (SettingsService.Instance.TaskbarUseAccentColor || SettingsService.Instance.TaskbarCustomTintColor.A > 0))
             {
                 Windows.UI.Color targetColor = SettingsService.Instance.TaskbarUseAccentColor
                     ? (Windows.UI.Color)Application.Current.Resources["SystemAccentColor"]
@@ -1098,20 +1138,20 @@ namespace FluentSensors.Features.TaskbarWidget
             }
             else if (_acrylicController == null && _micaController == null)
             {
-                // Native Windows 11 flyout background: #F9F9F9 for Light, #202020 for Dark
+                // Solid Mode (Transparency OFF or Solid material): #F2F2F2 Light, #222222 Dark
                 Windows.UI.Color bgColor = isLight
-                    ? Windows.UI.Color.FromArgb(255, 0xF9, 0xF9, 0xF9)
-                    : Windows.UI.Color.FromArgb(255, 0x20, 0x20, 0x20);
+                    ? Windows.UI.Color.FromArgb(255, 0xF2, 0xF2, 0xF2)
+                    : Windows.UI.Color.FromArgb(255, 0x22, 0x22, 0x22);
 
                 FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(bgColor);
             }
             else
             {
-                // Backdrop controller (Acrylic/Mica) handles the translucent background
+                // Translucent Mode: FlyoutRootBorder is transparent to let Acrylic backdrop show through
                 FlyoutRootBorder.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
             }
 
-            // Native Windows 11 flyout border: #BFBFBF for Light, #383838 for Dark
+            // Real border: #BFBFBF for Light, #383838 for Dark
             Windows.UI.Color borderColor = isLight
                 ? Windows.UI.Color.FromArgb(255, 0xBF, 0xBF, 0xBF)
                 : Windows.UI.Color.FromArgb(255, 0x38, 0x38, 0x38);
@@ -1161,15 +1201,11 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private void SetConfigurationSourceTheme()
         {
-            if (_configurationSource != null && this.Content is FrameworkElement frameworkElement)
-            {
-                _configurationSource.Theme = frameworkElement.ActualTheme switch
-                {
-                    ElementTheme.Dark => SystemBackdropTheme.Dark,
-                    ElementTheme.Light => SystemBackdropTheme.Light,
-                    _ => SystemBackdropTheme.Default
-                };
-            }
+            if (_isClosed || _configurationSource == null) return;
+
+            _configurationSource.Theme = IsCurrentThemeLight()
+                ? SystemBackdropTheme.Light
+                : SystemBackdropTheme.Dark;
         }
 
         // --- workaround: DWM backdrop swapchain kick ---

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -133,7 +133,7 @@ namespace FluentSensors.Features.TaskbarWidget
         public const int WindowSlideDistanceDip = 280;
 
         // animation duration in milliseconds
-        public const int EnterAnimationDurationMs = 240; // duration on open (move-in)
+        public const int EnterAnimationDurationMs = 260; // duration on open (move-in)
         public const int ExitAnimationDurationMs = 140;  // duration on close (move-out)
 
         // fade opacity (1.0f = no fade, 0.0f = full fade)

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -175,7 +175,13 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // Anchor offsets configurable in code-behind
         public const int FlyoutMarginToTaskbarDip = 12; // vertical gap between taskbar top and flyout bottom edge
-        public const int FlyoutHorizontalOffsetDip = 2; // horizontal offset relative to taskbar widget left (negative = left, positive = right)
+        public const int FlyoutMarginToScreenEdgeDip = 10; // smallest gap the flyout keeps to the left, right and top screen edges
+
+        // horizontal offset from the aligned edge, meaning depends on TaskbarFlyoutAlignment:
+        // Left = pixels to move right (inward from the widget left edge)
+        // Right = pixels to move left (inward from the widget right edge)
+        // Center = unused
+        public const int FlyoutHorizontalOffsetDip = 2;
 
         // default and minimum width in DIP (matching standard WidgetWindow width)
         public const int FlyoutDefaultWidthDip = 250;
@@ -294,6 +300,7 @@ namespace FluentSensors.Features.TaskbarWidget
             SettingsService.Instance.TaskbarBackdropTypeChanged += OnBackdropTypeChanged;
             SettingsService.Instance.TaskbarOpacityChanged += OnOpacityChanged;
             SettingsService.Instance.TaskbarTintColorChanged += OnTintColorChanged;
+            SettingsService.Instance.TaskbarFlyoutAlignmentChanged += OnFlyoutAlignmentChanged;
 
             ((FrameworkElement)this.Content).ActualThemeChanged += (s, e) =>
             {
@@ -612,6 +619,7 @@ namespace FluentSensors.Features.TaskbarWidget
                 SettingsService.Instance.TaskbarBackdropTypeChanged -= OnBackdropTypeChanged;
                 SettingsService.Instance.TaskbarOpacityChanged -= OnOpacityChanged;
                 SettingsService.Instance.TaskbarTintColorChanged -= OnTintColorChanged;
+                SettingsService.Instance.TaskbarFlyoutAlignmentChanged -= OnFlyoutAlignmentChanged;
             }
             catch { }
 
@@ -822,7 +830,9 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // === window sizing and positioning ===
 
-        // calculates and applies the bottom-left anchored placement directly above the taskbar widget
+        // places the flyout horizontally over the taskbar widget per TaskbarFlyoutAlignment (centered, left or right)
+        // and anchors its bottom edge just above the taskbar, then clamps the result so it never leaves the primary
+        // work area
         private void PositionAboveTaskbar(TaskbarWidgetWindow widgetWindow, bool startForSlideAnimation = false)
         {
             var widgetHwnd = WinRT.Interop.WindowNative.GetWindowHandle(widgetWindow);
@@ -863,30 +873,37 @@ namespace FluentSensors.Features.TaskbarWidget
                 desiredHeightPx = defaultHeightPx;
             }
 
-            // calculate bottom-left anchor
+            // vertical gap above the taskbar, horizontal placement over the widget per TaskbarFlyoutAlignment
             int marginPx = (int)Math.Round(FlyoutMarginToTaskbarDip * scale);
-            int hOffsetPx = (int)Math.Round(FlyoutHorizontalOffsetDip * scale);
+            int offsetPx = (int)Math.Round(FlyoutHorizontalOffsetDip * scale);
+            int edgeMarginPx = (int)Math.Round(FlyoutMarginToScreenEdgeDip * scale);
 
             _bottomAnchorY = primaryTaskbar != null ? (primaryTaskbar.Rect.Y - marginPx) : (widgetRect.Top - marginPx);
-            _leftAnchorX = widgetRect.Left + hOffsetPx;
 
-            _targetX = _leftAnchorX;
+            // Left/Right anchor to the matching widget edge and let the offset pull the flyout inward;
+            // Center ignores the offset and lines the flyout center up with the widget center
+            _targetX = SettingsService.Instance.TaskbarFlyoutAlignment switch
+            {
+                "Left" => widgetRect.Left + offsetPx,
+                "Right" => widgetRect.Right - desiredWidthPx - offsetPx,
+                _ => ((widgetRect.Left + widgetRect.Right) / 2) - (desiredWidthPx / 2)
+            };
             _targetY = _bottomAnchorY - desiredHeightPx;
 
-            // clamp within primary display work area
+            // clamp within the primary work area, never closer than edgeMarginPx to a left, right or top edge;
+            // the left edge wins when the screen is too narrow to honor both sides at once
             var workArea = DisplayArea.Primary.WorkArea;
-            if (_targetX + desiredWidthPx > workArea.X + workArea.Width - 10)
+            int rightLimitX = workArea.X + workArea.Width - desiredWidthPx - edgeMarginPx;
+            int leftLimitX = workArea.X + edgeMarginPx;
+            _targetX = Math.Max(leftLimitX, Math.Min(_targetX, rightLimitX));
+
+            if (_targetY < workArea.Y + edgeMarginPx)
             {
-                _targetX = workArea.X + workArea.Width - desiredWidthPx - 10;
+                _targetY = workArea.Y + edgeMarginPx;
             }
-            if (_targetX < workArea.X + 10)
-            {
-                _targetX = workArea.X + 10;
-            }
-            if (_targetY < workArea.Y + 10)
-            {
-                _targetY = workArea.Y + 10;
-            }
+
+            // the WM_SIZING resize path locks the window left edge to this, so it has to be the clamped value
+            _leftAnchorX = _targetX;
 
             int initialY = startForSlideAnimation
                 ? (_targetY + (int)Math.Round(WindowSlideDistanceDip * scale))
@@ -1085,6 +1102,17 @@ namespace FluentSensors.Features.TaskbarWidget
             {
                 UpdateAcrylicProperties();
                 UpdateSolidBackground();
+            });
+        }
+
+        // re-anchors the flyout when the alignment setting changes; the flyout is usually hidden at that point, so
+        // this just refreshes the target for the next open, same as ResetGeometry does after a size reset
+        private void OnFlyoutAlignmentChanged(string newAlignment)
+        {
+            this.DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_isClosed || TaskbarWidgetWindow.CurrentInstance == null) return;
+                PositionAboveTaskbar(TaskbarWidgetWindow.CurrentInstance, startForSlideAnimation: false);
             });
         }
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetViewModel.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetViewModel.cs
@@ -92,6 +92,16 @@ namespace FluentSensors.Features.TaskbarWidget
             }
         }
 
+        // re-resolves every pinned graphs color against the current settings and the live SystemAccentColor;
+        // the taskbar widget and the flyout share this ViewModel, so one call refreshes both
+        public void RefreshGraphColors()
+        {
+            foreach (var sensor in PinnedSensors)
+            {
+                sensor.RefreshGraphColor();
+            }
+        }
+
         // pauses or resumes live data subscription and resets baseline
         public void SetLiveDataActive(bool active)
         {

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml
@@ -113,7 +113,7 @@
                             VerticalAlignment="Stretch"
                             IsGraphHoverEnabled="False"
                             IsHitTestVisible="False"
-                            ShowGraphCardBackground="True"
+                            ShowGraphCardBackground="{x:Bind IsCardBackgroundVisible, Mode=OneWay}"
                             ShowGraphCardBorder="False"
                             ShowGraphLabel="True"
                             ShowStatusRow="False"

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -382,6 +382,10 @@ namespace FluentSensors.Features.TaskbarWidget
                 var carriedViewModel = live?.ViewModel;
                 int carriedOffsetDip = live?._currentOffsetDip ?? AnchorOffsetDip;
 
+                // the replacement window otherwise shows the pre-change accent: every rebuild trigger refreshes
+                // everything it rebuilds, and this carried ViewModel is precisely the thing that does not
+                carriedViewModel?.RefreshGraphColors();
+
                 if (live != null)
                 {
                     CurrentInstance = null;

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -99,6 +99,12 @@ namespace FluentSensors.Features.TaskbarWidget
         private bool _isEmbedded;
         private bool _embedGaveUp;
         public bool IsEmbedded => _isEmbedded;
+
+        // set only on the window a rebuild creates to replace a live one: it carries its predecessors drag offset,
+        // skips the startup animation, and reopens the flyout if the rebuild interrupted an open one
+        private bool _isRebuild;
+        private bool _restoreFlyoutAfterEmbed;
+
         private static TaskbarWidgetWindow _retainedInstance;
         public static TaskbarWidgetWindow CurrentInstance { get; private set; }
         public static event Action WidgetStateChanged;
@@ -114,9 +120,26 @@ namespace FluentSensors.Features.TaskbarWidget
 
         public TaskbarWidgetWindow(List<SensorRowViewModel> selectedSensors)
         {
+            ViewModel = new TaskbarWidgetViewModel(selectedSensors);
+            Initialize();
+        }
+
+        // rebuild path: takes over the ViewModel of the window it replaces, so the pinned graphs keep their history
+        // and the old instance leaves no second HardwareDataUpdated subscription behind
+        // see TaskbarFlyoutWindow.ScheduleRecreation for why the window is rebuilt at all
+        private TaskbarWidgetWindow(TaskbarWidgetViewModel viewModel, int offsetDip, bool restoreFlyout)
+        {
+            ViewModel = viewModel;
+            _currentOffsetDip = offsetDip;
+            _isRebuild = true;
+            _restoreFlyoutAfterEmbed = restoreFlyout;
+            Initialize();
+        }
+
+        private void Initialize()
+        {
             try
             {
-                ViewModel = new TaskbarWidgetViewModel(selectedSensors);
                 this.InitializeComponent();
                 CurrentInstance = this;
 
@@ -125,10 +148,14 @@ namespace FluentSensors.Features.TaskbarWidget
                 _hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
 
                 // restore previously saved drag offset along the taskbar if available
-                var savedState = WindowStateService.Instance.GetState(WindowKey);
-                if (savedState != null && savedState.X > 0)
+                // a rebuild already carries the offset of the window it replaces, see the rebuild constructor
+                if (!_isRebuild)
                 {
-                    _currentOffsetDip = savedState.X;
+                    var savedState = WindowStateService.Instance.GetState(WindowKey);
+                    if (savedState != null && savedState.X > 0)
+                    {
+                        _currentOffsetDip = savedState.X;
+                    }
                 }
 
                 // --- workaround: CreateForContextMenu crashes unpackaged ---
@@ -280,6 +307,111 @@ namespace FluentSensors.Features.TaskbarWidget
             TaskbarFlyoutWindow.ResetGeometry();
         }
 
+        private bool _isClosed = false;
+
+        // --- memory leak: taskbar widget instance never released after a real close ---
+        // problem: WinUI 3 never releases secondary Window objects back to the GC/OS after a real close
+        // confirmed, still-open platform bug, reproducible even with empty window content:
+        // https://github.com/microsoft/microsoft-ui-xaml/issues/9063
+        // everywhere else the answer is hide-and-reuse (CloseWidget re-registers _retainedInstance); this method is
+        // the one place that deliberately destroys the window, because a global transparency or accent change is only
+        // picked up by a window built after it, see TaskbarFlyoutWindow.ScheduleRecreation
+        // price: one leaked CCW per OS theme or transparency change, knowingly paid
+        //
+        // only ever call this from RecreateWindow, never from the normal close path
+        public void SafeDestroy(bool disposeViewModel)
+        {
+            if (_isClosed) return;
+            _isClosed = true;
+
+            try
+            {
+                SettingsService.Instance.TaskbarGraphWidthChanged -= OnTaskbarGraphWidthChanged;
+                SettingsService.Instance.ThemeChanged -= OnThemeChanged;
+            }
+            catch { }
+
+            // AppWindow_Closing cancels the close and re-registers this instance as _retainedInstance; detaching it
+            // here is what lets the Close below go through instead of resurrecting a window that is already torn down
+            try
+            {
+                _appWindow.Closing -= AppWindow_Closing;
+            }
+            catch { }
+
+            try
+            {
+                if (_taskbarHwnd != IntPtr.Zero)
+                {
+                    WinTaskbarEmbedder.Detach(_hwnd);
+                    _taskbarHwnd = IntPtr.Zero;
+                    _isEmbedded = false;
+                }
+            }
+            catch { }
+
+            try
+            {
+                // only the instance whose ViewModel nobody takes over releases it; the live one hands it to its
+                // replacement, and cleaning it up here would drop the graph history and the sensor subscription
+                if (disposeViewModel)
+                {
+                    ViewModel?.Cleanup();
+                }
+
+                _nonActivatingMonitor?.Dispose();
+                _nonActivatingMonitor = null;
+                this.Close();
+            }
+            catch { }
+        }
+
+        private static bool _isRecreating = false;
+
+        // fully destroys and rebuilds the taskbar widget when Windows global transparency or accent color changes,
+        // and tells the new window whether it has to bring an open flyout back with it
+        public static void RecreateWindow(bool restoreFlyout)
+        {
+            if (_isRecreating) return;
+            if (CurrentInstance == null && _retainedInstance == null) return;
+            _isRecreating = true;
+
+            try
+            {
+                var live = CurrentInstance;
+                var carriedViewModel = live?.ViewModel;
+                int carriedOffsetDip = live?._currentOffsetDip ?? AnchorOffsetDip;
+
+                if (live != null)
+                {
+                    CurrentInstance = null;
+                    live.SafeDestroy(disposeViewModel: false);
+                }
+
+                // a hidden widget has nothing on screen to refresh, so it is dropped rather than rebuilt; the next
+                // ShowWidget then builds one that matches the new OS settings
+                if (_retainedInstance != null)
+                {
+                    var old = _retainedInstance;
+                    _retainedInstance = null;
+                    old.SafeDestroy(disposeViewModel: true);
+                }
+
+                if (carriedViewModel == null) return;
+
+                // one dispatcher hop, so the Close above drains before the replacement window is built
+                var queue = DispatcherQueue.GetForCurrentThread() ?? MainWindow.CurrentInstance?.DispatcherQueue;
+                if (queue == null || !queue.TryEnqueue(() => _ = new TaskbarWidgetWindow(carriedViewModel, carriedOffsetDip, restoreFlyout)))
+                {
+                    _ = new TaskbarWidgetWindow(carriedViewModel, carriedOffsetDip, restoreFlyout);
+                }
+            }
+            finally
+            {
+                _isRecreating = false;
+            }
+        }
+
 
         // === embedding ===
 
@@ -367,41 +499,57 @@ namespace FluentSensors.Features.TaskbarWidget
                 _isEmbedded = true;
                 SaveWindowState(wasOpen: true);
 
-                // hide TaskbarButton initially before the delayed startup animation begins
-                if (TaskbarButton != null)
+                // a rebuild replaces a widget that is already sitting on the taskbar, so it skips the startup
+                // sequence; otherwise every OS accent or transparency change would blank the button for
+                // TaskbarStartupDelayMs and slide it in again
+                if (!_isRebuild)
                 {
-                    try
+                    // hide TaskbarButton initially before the delayed startup animation begins
+                    if (TaskbarButton != null)
                     {
-                        TaskbarButton.ApplyTemplate();
-                        var visual = ElementCompositionPreview.GetElementVisual(TaskbarButton);
-                        if (visual != null)
+                        try
                         {
-                            float slideDistPx = (float)(TaskbarStartupSlideDistanceDip * scale);
-                            visual.Offset = new Vector3(0, slideDistPx, 0);
-                            visual.Opacity = TaskbarStartupStartOpacity;
+                            TaskbarButton.ApplyTemplate();
+                            var visual = ElementCompositionPreview.GetElementVisual(TaskbarButton);
+                            if (visual != null)
+                            {
+                                float slideDistPx = (float)(TaskbarStartupSlideDistanceDip * scale);
+                                visual.Offset = new Vector3(0, slideDistPx, 0);
+                                visual.Opacity = TaskbarStartupStartOpacity;
+                            }
                         }
+                        catch { }
                     }
-                    catch { }
-                }
 
-                // play smooth slide-up startup animation on TaskbarButton after the specified startup delay
-                if (TaskbarStartupDelayMs > 0)
-                {
-                    var animTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(TaskbarStartupDelayMs) };
-                    animTimer.Tick += (s, e) =>
+                    // play smooth slide-up startup animation on TaskbarButton after the specified startup delay
+                    if (TaskbarStartupDelayMs > 0)
                     {
-                        animTimer.Stop();
-                        PlayStartupAnimation();
-                    };
-                    animTimer.Start();
-                }
-                else
-                {
-                    this.DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, PlayStartupAnimation);
+                        var animTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(TaskbarStartupDelayMs) };
+                        animTimer.Tick += (s, e) =>
+                        {
+                            animTimer.Stop();
+                            PlayStartupAnimation();
+                        };
+                        animTimer.Start();
+                    }
+                    else
+                    {
+                        this.DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, PlayStartupAnimation);
+                    }
                 }
 
                 // preload flyout window into memory to eliminate first-open latency
-                TaskbarFlyoutWindow.Preload(this);
+                // a rebuild that interrupted an open flyout reopens it here instead: the flyout anchors to the widget
+                // rect, so it can only be placed once the new widget sits on the taskbar again
+                if (_restoreFlyoutAfterEmbed)
+                {
+                    _restoreFlyoutAfterEmbed = false;
+                    TaskbarFlyoutWindow.ShowFlyout(this);
+                }
+                else
+                {
+                    TaskbarFlyoutWindow.Preload(this);
+                }
             }
             catch (Exception ex)
             {
@@ -503,6 +651,10 @@ namespace FluentSensors.Features.TaskbarWidget
         // same approach as WidgetWindow
         private void AppWindow_Closing(AppWindow sender, AppWindowClosingEventArgs args)
         {
+            // SafeDestroy is tearing this instance down: let the close proceed instead of handing a window that is
+            // already torn down back to _retainedInstance, where the next ShowWithSensors would try to reuse it
+            if (_isClosed) return;
+
             args.Cancel = true;
             CloseWidget();
         }

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -713,12 +713,14 @@ namespace FluentSensors.Features.TaskbarWidget
                 return new List<SensorRowViewModel>();
             }
 
-            var allSensors = SensorsViewModel.Instance.HardwareGroups
-                .SelectMany(g => g.Sensors.Concat(g.HiddenSensors));
+            // walks the groups rather than the id list so the row order matches what PinToWidget_Click and
+            // PinToTaskbar_Click produce; the persisted list is membership in toggle order, not display order,
+            // and mapping over it put restored graphs in a different order than a live pin of the same sensors
+            var wantedIds = new HashSet<string>(sensorIds);
 
-            return sensorIds
-                .Select(id => allSensors.FirstOrDefault(s => s.Id == id))
-                .Where(sensor => sensor != null)
+            return SensorsViewModel.Instance.HardwareGroups
+                .SelectMany(g => g.Sensors.Concat(g.HiddenSensors))
+                .Where(sensor => wantedIds.Contains(sensor.Id))
                 .ToList();
         }
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -843,7 +843,8 @@ namespace FluentSensors.Features.TaskbarWidget
             var ptr = e?.GetCurrentPoint(TaskbarButton);
             if (ptr != null && !ptr.Properties.IsLeftButtonPressed) return;
 
-            if (NativeMethods.GetCursorPos(out var cursorPos))
+            // skip all drag bookkeeping while the position is locked; press feedback and click-to-toggle stay live
+            if (!SettingsService.Instance.TaskbarWidgetPositionLocked && NativeMethods.GetCursorPos(out var cursorPos))
             {
                 _dragStartCursorScreenX = cursorPos.X;
                 _dragStartWindowScreenX = _currentScreenRect.X;

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -156,6 +156,8 @@ namespace FluentSensors.Features.TaskbarWidget
                 _appWindow.Closing += AppWindow_Closing;
 
                 SettingsService.Instance.TaskbarGraphWidthChanged += OnTaskbarGraphWidthChanged;
+                SettingsService.Instance.ThemeChanged += OnThemeChanged;
+                ApplyTheme(SettingsService.Instance.AppTheme);
 
                 // wire left-button press/release/drag animations and movement even when Button internally handles clicks
                 TaskbarButton.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(TaskbarButton_PointerPressed), true);
@@ -503,6 +505,25 @@ namespace FluentSensors.Features.TaskbarWidget
         {
             args.Cancel = true;
             CloseWidget();
+        }
+
+        private void OnThemeChanged(string newTheme)
+        {
+            this.DispatcherQueue.TryEnqueue(() => ApplyTheme(newTheme));
+        }
+
+        private void ApplyTheme(string themeTag)
+        {
+            if (this.Content is FrameworkElement rootElement)
+            {
+                rootElement.RequestedTheme = themeTag switch
+                {
+                    "Light" => ElementTheme.Light,
+                    "Dark" => ElementTheme.Dark,
+                    _ => ElementTheme.Default
+                };
+            }
+            UpdateVisualState();
         }
 
         private void OnTaskbarGraphWidthChanged(int newWidth)

--- a/FluentSensors/Features/Widget/WidgetViewModel.cs
+++ b/FluentSensors/Features/Widget/WidgetViewModel.cs
@@ -97,6 +97,16 @@ namespace FluentSensors.Features.Widget
         }
 
 
+        // re-resolves every pinned graphs color against the current settings and the live SystemAccentColor
+        public void RefreshGraphColors()
+        {
+            foreach (var sensor in PinnedSensors)
+            {
+                sensor.RefreshGraphColor();
+            }
+        }
+
+
         // fully couples or decouples the widget from the live hardware data stream; used for the closed (hidden) widget,
         // where nothing should run in the background at all
         // off: stops all incoming data (unsubscribes from HardwareMonitorService) and wipes every pinned graphs history

--- a/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
+++ b/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
@@ -295,12 +295,14 @@ namespace FluentSensors.Features.Widget
                 return new List<SensorRowViewModel>();
             }
 
-            var allSensors = SensorsViewModel.Instance.HardwareGroups
-                .SelectMany(g => g.Sensors.Concat(g.HiddenSensors));
+            // walks the groups rather than the id list so the row order matches what PinToWidget_Click and
+            // PinToTaskbar_Click produce; the persisted list is membership in toggle order, not display order,
+            // and mapping over it put restored graphs in a different order than a live pin of the same sensors
+            var wantedIds = new HashSet<string>(sensorIds);
 
-            return sensorIds
-                .Select(id => allSensors.FirstOrDefault(s => s.Id == id))
-                .Where(sensor => sensor != null)
+            return SensorsViewModel.Instance.HardwareGroups
+                .SelectMany(g => g.Sensors.Concat(g.HiddenSensors))
+                .Where(sensor => wantedIds.Contains(sensor.Id))
                 .ToList();
         }
 

--- a/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
+++ b/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
@@ -200,6 +200,16 @@ namespace FluentSensors.Features.Widget
             }
             catch { }
 
+            // AppWindow_Closing cancels the close and re-registers this instance as _retainedInstance; detaching it
+            // here is what lets the Close below go through instead of resurrecting a window that is already torn down
+            // WidgetWindow_Closed stays attached, it carries the real teardown once the close completes
+            try
+            {
+                _appWindow.Closing -= AppWindow_Closing;
+                _appWindow.Changed -= AppWindow_Changed;
+            }
+            catch { }
+
             try
             {
                 _acrylicController?.Dispose();
@@ -333,6 +343,10 @@ namespace FluentSensors.Features.Widget
         // command); this window never decides to quit on its own
         private void AppWindow_Closing(AppWindow sender, AppWindowClosingEventArgs args)
         {
+            // SafeDestroy is tearing this instance down: let the close proceed instead of handing a window with
+            // _isClosed set back to _retainedInstance, where every later SetBackdrop and ApplyTheme returns early
+            if (_isClosed) return;
+
             args.Cancel = true;
 
             SaveWindowState(wasOpen: false);

--- a/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
+++ b/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
@@ -50,7 +50,6 @@ namespace FluentSensors.Features.Widget
         private MicaController _micaController;
         private SystemBackdropConfiguration _configurationSource;
         private Windows.UI.ViewManagement.UISettings? _uiSettings;
-        private static bool _lastAdvancedEffects = true;
 
 
         // === constructor ===
@@ -117,8 +116,8 @@ namespace FluentSensors.Features.Widget
             try
             {
                 _uiSettings = new Windows.UI.ViewManagement.UISettings();
-                _uiSettings.AdvancedEffectsEnabledChanged += (s, e) => TaskbarFlyoutWindow.ScheduleRecreation();
-                _uiSettings.ColorValuesChanged += (s, e) => TaskbarFlyoutWindow.ScheduleRecreation();
+                _uiSettings.AdvancedEffectsEnabledChanged += OnSystemVisualSettingsChanged;
+                _uiSettings.ColorValuesChanged += OnSystemVisualSettingsChanged;
             }
             catch { }
 
@@ -200,6 +199,17 @@ namespace FluentSensors.Features.Widget
             }
             catch { }
 
+            try
+            {
+                if (_uiSettings != null)
+                {
+                    _uiSettings.AdvancedEffectsEnabledChanged -= OnSystemVisualSettingsChanged;
+                    _uiSettings.ColorValuesChanged -= OnSystemVisualSettingsChanged;
+                    _uiSettings = null;
+                }
+            }
+            catch { }
+
             // AppWindow_Closing cancels the close and re-registers this instance as _retainedInstance; detaching it
             // here is what lets the Close below go through instead of resurrecting a window that is already torn down
             // WidgetWindow_Closed stays attached, it carries the real teardown once the close completes
@@ -250,7 +260,11 @@ namespace FluentSensors.Features.Widget
 
             if (sensors.Count > 0 && wasVisible)
             {
-                MainWindow.CurrentInstance?.DispatcherQueue.TryEnqueue(() =>
+                // the queue has to be resolved with a fallback: closing the main window to the tray leaves
+                // MainWindow.CurrentInstance null, and a null-conditional TryEnqueue there would skip the finally
+                // below and latch _isRecreating for the rest of the session, so the widget would never rebuild again
+                var queue = MainWindow.CurrentInstance?.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread();
+                bool queued = queue != null && queue.TryEnqueue(() =>
                 {
                     try
                     {
@@ -261,6 +275,11 @@ namespace FluentSensors.Features.Widget
                         _isRecreating = false;
                     }
                 });
+
+                if (!queued)
+                {
+                    _isRecreating = false;
+                }
             }
             else
             {
@@ -420,20 +439,11 @@ namespace FluentSensors.Features.Widget
             });
         }
 
-        private void OnAdvancedEffectsEnabledChanged(Windows.UI.ViewManagement.UISettings sender, object args)
+        // a named handler rather than a lambda, so SafeDestroy can detach it again; every rebuilt window subscribes
+        // anew and without the detach the UISettings handler list grows by one per rebuild
+        private void OnSystemVisualSettingsChanged(Windows.UI.ViewManagement.UISettings sender, object args)
         {
-            try
-            {
-                bool current = sender.AdvancedEffectsEnabled;
-                if (current == _lastAdvancedEffects) return; // ignore spurious theme change events
-                _lastAdvancedEffects = current;
-            }
-            catch { }
-
-            this.DispatcherQueue.TryEnqueue(() =>
-            {
-                SetBackdrop(SettingsService.Instance.BackdropType);
-            });
+            TaskbarFlyoutWindow.ScheduleRecreation();
         }
 
         private void AppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs args)

--- a/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
+++ b/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
@@ -116,6 +116,7 @@ namespace FluentSensors.Features.Widget
             try
             {
                 _uiSettings = new Windows.UI.ViewManagement.UISettings();
+                TaskbarFlyoutWindow.SeedSystemVisualsSnapshot(_uiSettings);
                 _uiSettings.AdvancedEffectsEnabledChanged += OnSystemVisualSettingsChanged;
                 _uiSettings.ColorValuesChanged += OnSystemVisualSettingsChanged;
             }
@@ -441,9 +442,12 @@ namespace FluentSensors.Features.Widget
 
         // a named handler rather than a lambda, so SafeDestroy can detach it again; every rebuilt window subscribes
         // anew and without the detach the UISettings handler list grows by one per rebuild
+        //
+        // routes to RouteSystemVisualsChange rather than ScheduleRecreation directly, see TaskbarFlyoutWindows own
+        // handler for why: a pure accent change resolves into an in-place refresh instead of a rebuild
         private void OnSystemVisualSettingsChanged(Windows.UI.ViewManagement.UISettings sender, object args)
         {
-            TaskbarFlyoutWindow.ScheduleRecreation();
+            TaskbarFlyoutWindow.RouteSystemVisualsChange(sender);
         }
 
         private void AppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs args)
@@ -700,6 +704,14 @@ namespace FluentSensors.Features.Widget
 
                 RootGrid.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(targetColor);
             }
+        }
+
+        // re-reads the live SystemAccentColor into the acrylic tint and the solid background, for a pure OS
+        // accent change; both already resolve the accent fresh on every call, so no window rebuild is needed
+        public void RefreshAccentSurfaces()
+        {
+            UpdateAcrylicProperties();
+            UpdateSolidBackground();
         }
 
         // dynamically applies the chosen backdrop material to the WidgetWindow based on the users selection in the settings

--- a/FluentSensors/MainWindow.xaml.cs
+++ b/FluentSensors/MainWindow.xaml.cs
@@ -74,6 +74,9 @@ namespace FluentSensors
         private bool _isHardwareServiceLoaded = false;
         private bool _isDashboardClosed = false;
 
+        // profile a caller asked for while the splash was still running; applied once the sensor page exists
+        private SensorSelectionProfile? _pendingSensorProfile = null;
+
         // system tray icon commands
         public XamlUICommand RestoreAppCommand { get; } = new XamlUICommand(); // restore
         public XamlUICommand ShowMainWindowCommand { get; } = new XamlUICommand(); // restore + navigate to SensorPage
@@ -270,6 +273,14 @@ namespace FluentSensors
             AppStatus.IsAppReady = true;
             AppStatus.IsDotNetRuntimeMissing = !WinStaticInfoService.Instance.IsDotNetRuntimeInstalled;
             MainNavigationView.SelectedItem = MainNavigationView.MenuItems[0];
+
+            // a profile request that arrived before the page existed; the selection above is what finally creates it
+            if (_pendingSensorProfile is SensorSelectionProfile pendingProfile
+                && contentFrame.Content is SensorsPage pendingPage)
+            {
+                pendingPage.SelectProfile(pendingProfile);
+                _pendingSensorProfile = null;
+            }
 
             // re-open the widget window with its previously pinned sensors, if it was still open when the app last closed
             TryRestoreWidgetWindow();
@@ -605,6 +616,35 @@ namespace FluentSensors
             }
             this.Activate();
             SetForegroundWindow(hwnd); // see workaround comment on the P/Invoke declaration above
+        }
+
+        // restores the window and lands on the sensor list with a specific profile preselected
+        // used by the taskbar flyout, whose bottom bar action is about the taskbar selection specifically
+        //
+        // deliberately not routed through ShowMainWindowCommand: that one goes via RestoreApp, which is gated on
+        // _isDashboardClosed (so it stays silent after the user closed the window with X) and also drags the
+        // widget window back up, which is not wanted from the taskbar flyout
+        public void OpenSensorsForProfile(SensorSelectionProfile profile)
+        {
+            OpenDashboard();
+
+            // NavigationView raises SelectionChanged only on an actual change, so re-selecting the already active
+            // sensor item would never navigate; the profile below is applied either way
+            var sensorsItem = MainNavigationView.MenuItems[0];
+            if (!ReferenceEquals(MainNavigationView.SelectedItem, sensorsItem))
+            {
+                MainNavigationView.SelectedItem = sensorsItem;
+            }
+
+            if (contentFrame.Content is SensorsPage sensorsPage)
+            {
+                sensorsPage.SelectProfile(profile);
+            }
+            else
+            {
+                // splash is still running, StartHardwareServiceAsync picks this up once it selects the page
+                _pendingSensorProfile = profile;
+            }
         }
 
         private void RestoreApp()

--- a/FluentSensors/MainWindow.xaml.cs
+++ b/FluentSensors/MainWindow.xaml.cs
@@ -321,16 +321,17 @@ namespace FluentSensors
             FluentSensors.Features.TaskbarWidget.TaskbarWidgetWindow.ShowWithSensors(pinnedSensors);
         }
 
-        // looks up live SensorRowViewModel instances (visible or hidden) by their saved IDs, preserving the original
-        // pin order rather than whatever order the hardware groups produce
+        // looks up live SensorRowViewModel instances (visible or hidden) by their saved IDs, in hardware discovery
+        // order so a restored widget shows the same order a live pin of the same sensors would
+        // the saved list is membership in toggle order; mapping over it instead reproduced that toggle order, which
+        // is what made restored graphs come back in a different order than they were pinned in
         private List<SensorRowViewModel> FindSensorRowsByIds(IReadOnlyList<string> ids)
         {
-            var allSensors = SensorsViewModel.Instance.HardwareGroups
-                .SelectMany(g => g.Sensors.Concat(g.HiddenSensors));
+            var wantedIds = new HashSet<string>(ids);
 
-            return ids
-                .Select(id => allSensors.FirstOrDefault(s => s.Id == id))
-                .Where(s => s != null)
+            return SensorsViewModel.Instance.HardwareGroups
+                .SelectMany(g => g.Sensors.Concat(g.HiddenSensors))
+                .Where(s => wantedIds.Contains(s.Id))
                 .ToList();
         }
 

--- a/FluentSensors/Persistence/Models/AppSettingsData.cs
+++ b/FluentSensors/Persistence/Models/AppSettingsData.cs
@@ -21,14 +21,14 @@ namespace FluentSensors.Persistence.Models
         public double GraphTimeSpanSeconds { get; set; } = 45;
 
         // taskbar ecosystem (taskbar widget + flyout window) appearance
-        public string TaskbarBackdropType { get; set; } = "Acrylic";
+        public string TaskbarBackdropType { get; set; } = "Mica";
         public float TaskbarTintOpacity { get; set; } = 0.4f;
         public float TaskbarLuminosityOpacity { get; set; } = 0.2f;
         public bool TaskbarUseAccentColor { get; set; } = true;
         public Color TaskbarCustomTintColor { get; set; } = Color.FromArgb(255, 25, 25, 25);
         public bool TaskbarUseGraphAccentColor { get; set; } = true;
         public Windows.UI.Color TaskbarGraphCustomColor { get; set; } = Microsoft.UI.Colors.LightBlue;
-        public double TaskbarGraphTimeSpanSeconds { get; set; } = 45;
+        public double TaskbarGraphTimeSpanSeconds { get; set; } = 20;
         public int TaskbarGraphWidthDip { get; set; } = 120;
         public bool TaskbarUseTransparentGraphBackground { get; set; } = false;
 

--- a/FluentSensors/Persistence/Models/AppSettingsData.cs
+++ b/FluentSensors/Persistence/Models/AppSettingsData.cs
@@ -31,6 +31,12 @@ namespace FluentSensors.Persistence.Models
         public double TaskbarGraphTimeSpanSeconds { get; set; } = 45;
         public int TaskbarGraphWidthDip { get; set; } = 120;
 
+        // flyout horizontal placement over the taskbar widget: "Center", "Left" or "Right"
+        public string TaskbarFlyoutAlignment { get; set; } = "Center";
+
+        // when true, the taskbar widget cannot be dragged along the taskbar
+        public bool TaskbarWidgetPositionLocked { get; set; } = false;
+
         public bool MinimizeToTray { get; set; } = true;
         public bool HideSensorsCompletely { get; set; } = true;
         public bool StatusReadoutEnabled { get; set; } = true;

--- a/FluentSensors/Persistence/Models/AppSettingsData.cs
+++ b/FluentSensors/Persistence/Models/AppSettingsData.cs
@@ -30,6 +30,7 @@ namespace FluentSensors.Persistence.Models
         public Windows.UI.Color TaskbarGraphCustomColor { get; set; } = Microsoft.UI.Colors.LightBlue;
         public double TaskbarGraphTimeSpanSeconds { get; set; } = 45;
         public int TaskbarGraphWidthDip { get; set; } = 120;
+        public bool TaskbarUseTransparentGraphBackground { get; set; } = false;
 
         // flyout horizontal placement over the taskbar widget: "Center", "Left" or "Right"
         public string TaskbarFlyoutAlignment { get; set; } = "Center";

--- a/FluentSensors/Persistence/Models/SensorSelectionState.cs
+++ b/FluentSensors/Persistence/Models/SensorSelectionState.cs
@@ -3,8 +3,9 @@
 
 namespace FluentSensors.Persistence.Models
 {
-    // persisted ordered sensor ids for the three selection profiles (widget window, csv, taskbar)
-    // order matters here, it is the exact row order each profiles consumer displays
+    // persisted sensor ids for the three selection profiles (widget window, csv, taskbar)
+    // this is membership only, in the order the checkboxes happened to be toggled; the order a consumer displays
+    // is resolved from hardware discovery order at load time, not from this list
     public class SensorSelectionState
     {
         public List<string> WidgetWindow { get; set; } = new();

--- a/FluentSensors/Persistence/Models/WindowState.cs
+++ b/FluentSensors/Persistence/Models/WindowState.cs
@@ -13,9 +13,6 @@ namespace FluentSensors.Persistence.Models
         public int Height { get; set; }
         public bool IsMaximized { get; set; }
 
-        // number of pinned sensors when size was saved (used by TaskbarFlyoutWindow to reset on count change)
-        public int? SensorCount { get; set; }
-
         // WidgetWindow only: whether it was open when the app last closed, so it can be automatically restored on
         // next launch; which sensors to restore it with comes from SensorSelectionService, not from here
         public bool WasOpen { get; set; }

--- a/FluentSensors/Persistence/Services/SettingsService.cs
+++ b/FluentSensors/Persistence/Services/SettingsService.cs
@@ -299,6 +299,22 @@ namespace FluentSensors.Persistence.Services
             }
         }
 
+        // when true the taskbar widget graphs drop their calculated card tint and stay fully transparent
+        private bool _taskbarUseTransparentGraphBackground = false;
+        public bool TaskbarUseTransparentGraphBackground
+        {
+            get => _taskbarUseTransparentGraphBackground;
+            set
+            {
+                if (_taskbarUseTransparentGraphBackground != value)
+                {
+                    _taskbarUseTransparentGraphBackground = value;
+                    TaskbarGraphBackgroundChanged?.Invoke(_taskbarUseTransparentGraphBackground);
+                    SaveDebounced();
+                }
+            }
+        }
+
         // flyout horizontal placement over the taskbar widget: "Center", "Left" or "Right"
         private string _taskbarFlyoutAlignment = "Center";
         public string TaskbarFlyoutAlignment
@@ -404,6 +420,7 @@ namespace FluentSensors.Persistence.Services
             _taskbarGraphCustomColor = data.TaskbarGraphCustomColor;
             _taskbarGraphTimeSpanSeconds = data.TaskbarGraphTimeSpanSeconds;
             _taskbarGraphWidthDip = data.TaskbarGraphWidthDip;
+            _taskbarUseTransparentGraphBackground = data.TaskbarUseTransparentGraphBackground;
             _taskbarFlyoutAlignment = data.TaskbarFlyoutAlignment;
             _taskbarWidgetPositionLocked = data.TaskbarWidgetPositionLocked;
 
@@ -439,6 +456,7 @@ namespace FluentSensors.Persistence.Services
                 TaskbarGraphCustomColor = _taskbarGraphCustomColor,
                 TaskbarGraphTimeSpanSeconds = _taskbarGraphTimeSpanSeconds,
                 TaskbarGraphWidthDip = _taskbarGraphWidthDip,
+                TaskbarUseTransparentGraphBackground = _taskbarUseTransparentGraphBackground,
                 TaskbarFlyoutAlignment = _taskbarFlyoutAlignment,
                 TaskbarWidgetPositionLocked = _taskbarWidgetPositionLocked,
 
@@ -481,6 +499,7 @@ namespace FluentSensors.Persistence.Services
         public event Action<bool, Windows.UI.Color> TaskbarGraphColorChanged;
         public event Action<double> TaskbarGraphTimeSpanChanged;
         public event Action<int> TaskbarGraphWidthChanged;
+        public event Action<bool> TaskbarGraphBackgroundChanged;
         public event Action<string> TaskbarFlyoutAlignmentChanged;
         public event Action<bool> TaskbarWidgetPositionLockedChanged;
 

--- a/FluentSensors/Persistence/Services/SettingsService.cs
+++ b/FluentSensors/Persistence/Services/SettingsService.cs
@@ -299,6 +299,38 @@ namespace FluentSensors.Persistence.Services
             }
         }
 
+        // flyout horizontal placement over the taskbar widget: "Center", "Left" or "Right"
+        private string _taskbarFlyoutAlignment = "Center";
+        public string TaskbarFlyoutAlignment
+        {
+            get => _taskbarFlyoutAlignment;
+            set
+            {
+                if (_taskbarFlyoutAlignment != value)
+                {
+                    _taskbarFlyoutAlignment = value;
+                    TaskbarFlyoutAlignmentChanged?.Invoke(_taskbarFlyoutAlignment);
+                    SaveDebounced();
+                }
+            }
+        }
+
+        // when true, the taskbar widget cannot be dragged along the taskbar
+        private bool _taskbarWidgetPositionLocked = false;
+        public bool TaskbarWidgetPositionLocked
+        {
+            get => _taskbarWidgetPositionLocked;
+            set
+            {
+                if (_taskbarWidgetPositionLocked != value)
+                {
+                    _taskbarWidgetPositionLocked = value;
+                    TaskbarWidgetPositionLockedChanged?.Invoke(_taskbarWidgetPositionLocked);
+                    SaveDebounced();
+                }
+            }
+        }
+
 
         // --- App Behavior Settings ---
 
@@ -372,6 +404,8 @@ namespace FluentSensors.Persistence.Services
             _taskbarGraphCustomColor = data.TaskbarGraphCustomColor;
             _taskbarGraphTimeSpanSeconds = data.TaskbarGraphTimeSpanSeconds;
             _taskbarGraphWidthDip = data.TaskbarGraphWidthDip;
+            _taskbarFlyoutAlignment = data.TaskbarFlyoutAlignment;
+            _taskbarWidgetPositionLocked = data.TaskbarWidgetPositionLocked;
 
             _minimizeToTray = data.MinimizeToTray;
             _hideSensorsCompletely = data.HideSensorsCompletely;
@@ -405,6 +439,8 @@ namespace FluentSensors.Persistence.Services
                 TaskbarGraphCustomColor = _taskbarGraphCustomColor,
                 TaskbarGraphTimeSpanSeconds = _taskbarGraphTimeSpanSeconds,
                 TaskbarGraphWidthDip = _taskbarGraphWidthDip,
+                TaskbarFlyoutAlignment = _taskbarFlyoutAlignment,
+                TaskbarWidgetPositionLocked = _taskbarWidgetPositionLocked,
 
                 MinimizeToTray = _minimizeToTray,
                 HideSensorsCompletely = _hideSensorsCompletely,
@@ -445,6 +481,8 @@ namespace FluentSensors.Persistence.Services
         public event Action<bool, Windows.UI.Color> TaskbarGraphColorChanged;
         public event Action<double> TaskbarGraphTimeSpanChanged;
         public event Action<int> TaskbarGraphWidthChanged;
+        public event Action<string> TaskbarFlyoutAlignmentChanged;
+        public event Action<bool> TaskbarWidgetPositionLockedChanged;
 
         public event Action<bool> MinimizeToTrayChanged;
         public event Action<bool> HideSensorsCompletelyChanged;

--- a/FluentSensors/Persistence/Services/SettingsService.cs
+++ b/FluentSensors/Persistence/Services/SettingsService.cs
@@ -164,7 +164,7 @@ namespace FluentSensors.Persistence.Services
 
         // --- Taskbar Ecosystem (Widget + Flyout) Appearance Settings ---
 
-        private string _taskbarBackdropType = "Acrylic";
+        private string _taskbarBackdropType = "Mica";
         public string TaskbarBackdropType
         {
             get => _taskbarBackdropType;
@@ -269,7 +269,7 @@ namespace FluentSensors.Persistence.Services
             }
         }
 
-        private double _taskbarGraphTimeSpanSeconds = 45;
+        private double _taskbarGraphTimeSpanSeconds = 20;
         public double TaskbarGraphTimeSpanSeconds
         {
             get => _taskbarGraphTimeSpanSeconds;


### PR DESCRIPTION
## What does this change

Reworks the taskbar flyout so it renders correctly across every backdrop and Windows
transparency combination, sizes and animates itself from the pinned sensor count, and
survives OS visual changes without a full window rebuild.

The flyout background is now resolved per backdrop type x Windows transparency x app
theme instead of a single static brush, with the acrylic grain painted by hand because
the system backdrop controller does not composite one. Flyout height follows the number
of pinned graphs up to a cap, past which the graph list scrolls. Slide-in and slide-out
run off the compositor frame and scale their duration and travel distance with the
sensor count.

A pure Windows accent change now refreshes the graph colors and acrylic surfaces in
place; only a backdrop or transparency change still rebuilds the window. The rebuild
path carries the existing ViewModel over, so pinned graphs keep their history.

Adds four settings (flyout alignment, widget position lock, taskbar graph background
source, plus new defaults), reworks the flyout bottom bar into a command bar whose
action navigates to the sensor list on the taskbar profile, and fixes two persistence
and scoping bugs.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English