### PR TITLE
Make the taskbar window follow the Windows theme

### DIFF
--- a/FluentSensors/Common/UI/DefaultTextColor.cs
+++ b/FluentSensors/Common/UI/DefaultTextColor.cs
@@ -25,20 +25,25 @@ namespace FluentSensors.Common.UI
         private static readonly Windows.UI.Color LightColor = Windows.UI.Color.FromArgb(0xE4, 0x00, 0x00, 0x00);
         private static readonly Windows.UI.Color DarkColor = Windows.UI.Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF);
 
-        // followSystemTheme skips the app theme setting entirely, for the surfaces that track Windows instead of
-        // the app; the taskbar widget is the only one, see TaskbarWidgetWindow.ApplyWindowsTheme
-        public static Brush Resolve(bool followSystemTheme = false)
+        // for callers with no element to ask, which resolves against the app theme setting
+        public static Brush Resolve()
         {
-            bool isDark = followSystemTheme
-                ? Application.Current.RequestedTheme == ApplicationTheme.Dark
-                : SettingsService.Instance.AppTheme switch
-                {
-                    "Light" => false,
-                    "Dark" => true,
-                    // "Default" follows the OS theme, mirrors ApplyTheme()'s ElementTheme.Default behavior
-                    _ => Application.Current.RequestedTheme == ApplicationTheme.Dark
-                };
+            bool isDark = SettingsService.Instance.AppTheme switch
+            {
+                "Light" => false,
+                "Dark" => true,
+                // "Default" follows the OS theme, mirrors ApplyTheme()'s ElementTheme.Default behavior
+                _ => Application.Current.RequestedTheme == ApplicationTheme.Dark
+            };
 
+            return ForTheme(isDark);
+        }
+
+        // for callers that render in a known theme, which anything with an ActualTheme to read does
+        // more reliable than Resolve() wherever a control can end up in a window that does not follow the app theme
+        // setting, see SensorPanelControl
+        public static Brush ForTheme(bool isDark)
+        {
             return new SolidColorBrush(isDark ? DarkColor : LightColor);
         }
     }

--- a/FluentSensors/Common/UI/DefaultTextColor.cs
+++ b/FluentSensors/Common/UI/DefaultTextColor.cs
@@ -25,15 +25,19 @@ namespace FluentSensors.Common.UI
         private static readonly Windows.UI.Color LightColor = Windows.UI.Color.FromArgb(0xE4, 0x00, 0x00, 0x00);
         private static readonly Windows.UI.Color DarkColor = Windows.UI.Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF);
 
-        public static Brush Resolve()
+        // followSystemTheme skips the app theme setting entirely, for the surfaces that track Windows instead of
+        // the app; the taskbar widget is the only one, see TaskbarWidgetWindow.ApplyWindowsTheme
+        public static Brush Resolve(bool followSystemTheme = false)
         {
-            bool isDark = SettingsService.Instance.AppTheme switch
-            {
-                "Light" => false,
-                "Dark" => true,
-                // "Default" follows the OS theme, mirrors ApplyTheme()'s ElementTheme.Default behavior
-                _ => Application.Current.RequestedTheme == ApplicationTheme.Dark
-            };
+            bool isDark = followSystemTheme
+                ? Application.Current.RequestedTheme == ApplicationTheme.Dark
+                : SettingsService.Instance.AppTheme switch
+                {
+                    "Light" => false,
+                    "Dark" => true,
+                    // "Default" follows the OS theme, mirrors ApplyTheme()'s ElementTheme.Default behavior
+                    _ => Application.Current.RequestedTheme == ApplicationTheme.Dark
+                };
 
             return new SolidColorBrush(isDark ? DarkColor : LightColor);
         }

--- a/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
@@ -39,7 +39,7 @@ namespace FluentSensors.Controls.SensorGraph
             Scope = scope;
             Unit = SensorUnitFormatter.GetUnit(sensorType);
             CurrentValueText = "-"; // placeholder text until we have the first value
-            CurrentValueColor = DefaultTextColor.Resolve(FollowsSystemTheme);
+            CurrentValueColor = DefaultTextColor.Resolve();
 
             // when set, this instance owns a fixed time span independent of the scope GraphTimeSpanSeconds setting
             _timeSpanOverrideSeconds = graphTimeSpanSecondsOverride;
@@ -89,9 +89,12 @@ namespace FluentSensors.Controls.SensorGraph
 
         public SensorGraphScope Scope { get; }
 
-        // the taskbar widget window follows the Windows theme rather than the app theme setting, so its graphs have to
-        // resolve their text color the same way or they end up unreadable whenever the two disagree
-        private bool FollowsSystemTheme => Scope == SensorGraphScope.Taskbar;
+        // whether CurrentValueColor currently carries a threshold override rather than the plain default text color
+        // consumers that resolve the default against their own theme instead need to tell the two apart, see
+        // SensorPanelControl.GetCurrentValueColorOrDefault
+        // deliberately no change notification of its own; it is only ever set together with CurrentValueColor below,
+        // whose notification already carries the refresh
+        public bool IsThresholdColorActive { get; private set; }
 
         // general
         public ObservableCollection<double?> SensorData { get; private set; }
@@ -448,9 +451,11 @@ namespace FluentSensors.Controls.SensorGraph
         // re-evaluates the current values color against this sensors own threshold config
         private void RecalculateColor()
         {
-            CurrentValueColor = Threshold.IsBreached(_currentRaw)
+            IsThresholdColorActive = Threshold.IsBreached(_currentRaw);
+
+            CurrentValueColor = IsThresholdColorActive
                 ? new SolidColorBrush(Threshold.Color)
-                : DefaultTextColor.Resolve(FollowsSystemTheme);
+                : DefaultTextColor.Resolve();
         }
 
         // calculates, what has to be displayed in the UI as the current max value

--- a/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
@@ -39,7 +39,7 @@ namespace FluentSensors.Controls.SensorGraph
             Scope = scope;
             Unit = SensorUnitFormatter.GetUnit(sensorType);
             CurrentValueText = "-"; // placeholder text until we have the first value
-            CurrentValueColor = DefaultTextColor.Resolve();
+            CurrentValueColor = DefaultTextColor.Resolve(FollowsSystemTheme);
 
             // when set, this instance owns a fixed time span independent of the scope GraphTimeSpanSeconds setting
             _timeSpanOverrideSeconds = graphTimeSpanSecondsOverride;
@@ -88,6 +88,10 @@ namespace FluentSensors.Controls.SensorGraph
         // === bindable properties ===
 
         public SensorGraphScope Scope { get; }
+
+        // the taskbar widget window follows the Windows theme rather than the app theme setting, so its graphs have to
+        // resolve their text color the same way or they end up unreadable whenever the two disagree
+        private bool FollowsSystemTheme => Scope == SensorGraphScope.Taskbar;
 
         // general
         public ObservableCollection<double?> SensorData { get; private set; }
@@ -446,7 +450,7 @@ namespace FluentSensors.Controls.SensorGraph
         {
             CurrentValueColor = Threshold.IsBreached(_currentRaw)
                 ? new SolidColorBrush(Threshold.Color)
-                : DefaultTextColor.Resolve();
+                : DefaultTextColor.Resolve(FollowsSystemTheme);
         }
 
         // calculates, what has to be displayed in the UI as the current max value

--- a/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml.cs
@@ -519,7 +519,16 @@ namespace FluentSensors.Controls.SensorGraph
 
         private string GetCurrentValueOrPlaceholder(SensorGraphViewModel viewModel) => GetTextOrPlaceholder(viewModel?.CurrentValueText);
 
-        private Brush GetCurrentValueColorOrDefault(SensorGraphViewModel viewModel) => viewModel?.CurrentValueColor ?? DefaultTextColor.Resolve();
+        // the plain value color comes from this controls own ActualTheme rather than from the view model, because the
+        // taskbar widget and the taskbar flyout render the very same view model instances at the same time and can sit
+        // on different themes: the widget follows Windows, the flyout follows the app theme setting
+        // only a threshold override still comes from the view model, since that color is theme independent
+        private Brush GetCurrentValueColorOrDefault(SensorGraphViewModel viewModel)
+        {
+            if (viewModel != null && viewModel.IsThresholdColorActive) return viewModel.CurrentValueColor;
+
+            return DefaultTextColor.ForTheme(ActualTheme == ElementTheme.Dark);
+        }
 
         private string GetStatusRowTitleOrPlaceholder(bool showUnit, SensorGraphViewModel viewModel) =>
             viewModel == null ? "--" : GetTextOrPlaceholder(GetStatusRowTitle(showUnit, viewModel.SensorName, viewModel.DisplayNameWithUnit));

--- a/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Linq;
 
 using FluentSensors.Common.UI;
-using FluentSensors.Persistence.Services;
 
 
 namespace FluentSensors.Controls.SensorGraph
@@ -619,16 +618,13 @@ namespace FluentSensors.Controls.SensorGraph
             return null;
         }
 
-        // same resolution order as DefaultTextColor.Resolve; a code-behind theme-resource lookup would ignore the apps
-        // RequestedTheme override, so the app theme setting is read directly with the OS theme as the fallback
-        private static bool IsDarkTheme()
+        // ActualTheme is whatever this instance actually renders in, so it already accounts for the window it sits
+        // in overriding the theme; reading the app theme setting instead got this wrong in the taskbar widget, which
+        // deliberately follows Windows rather than the setting
+        // the ActualThemeChanged handler in the constructor re-runs the bindings that depend on this
+        private bool IsDarkTheme()
         {
-            return SettingsService.Instance.AppTheme switch
-            {
-                "Light" => false,
-                "Dark" => true,
-                _ => Application.Current.RequestedTheme == ApplicationTheme.Dark
-            };
+            return ActualTheme == ElementTheme.Dark;
         }
 
         private Windows.UI.Color? BoolToCardBorderOverride(bool showBorder) =>

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -665,10 +665,10 @@ namespace FluentSensors.Features.TaskbarWidget
         // apps own theme setting; every other window (main, widget, hidden sensors, taskbar flyout) keeps following
         // the setting, so a light app on a dark Windows leaves this one dark and blending into the taskbar
         //
-        // ElementTheme.Default inherits Application.Current.RequestedTheme, which is the Windows theme here since the
-        // app never overrides it
-        // it is set once and never revisited: nothing in the app can change it, and a Windows theme switch at runtime
-        // does not update Application.Current.RequestedTheme either, exactly as for every other window
+        // ElementTheme.Default inherits the app level theme, which is the Windows theme here since the app never
+        // overrides it
+        // set once and never revisited on purpose: Default keeps tracking Windows by itself from there, including a
+        // theme switch while the app is running
         private void ApplyWindowsTheme()
         {
             if (this.Content is FrameworkElement rootElement)

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -183,8 +183,7 @@ namespace FluentSensors.Features.TaskbarWidget
                 _appWindow.Closing += AppWindow_Closing;
 
                 SettingsService.Instance.TaskbarGraphWidthChanged += OnTaskbarGraphWidthChanged;
-                SettingsService.Instance.ThemeChanged += OnThemeChanged;
-                ApplyTheme(SettingsService.Instance.AppTheme);
+                ApplyWindowsTheme();
 
                 // wire left-button press/release/drag animations and movement even when Button internally handles clicks
                 TaskbarButton.AddHandler(UIElement.PointerPressedEvent, new PointerEventHandler(TaskbarButton_PointerPressed), true);
@@ -327,7 +326,6 @@ namespace FluentSensors.Features.TaskbarWidget
             try
             {
                 SettingsService.Instance.TaskbarGraphWidthChanged -= OnTaskbarGraphWidthChanged;
-                SettingsService.Instance.ThemeChanged -= OnThemeChanged;
             }
             catch { }
 
@@ -663,22 +661,21 @@ namespace FluentSensors.Features.TaskbarWidget
             CloseWidget();
         }
 
-        private void OnThemeChanged(string newTheme)
-        {
-            this.DispatcherQueue.TryEnqueue(() => ApplyTheme(newTheme));
-        }
-
-        private void ApplyTheme(string themeTag)
+        // this window sits inside the Windows taskbar, so it follows the Windows theme and deliberately ignores the
+        // apps own theme setting; every other window (main, widget, hidden sensors, taskbar flyout) keeps following
+        // the setting, so a light app on a dark Windows leaves this one dark and blending into the taskbar
+        //
+        // ElementTheme.Default inherits Application.Current.RequestedTheme, which is the Windows theme here since the
+        // app never overrides it
+        // it is set once and never revisited: nothing in the app can change it, and a Windows theme switch at runtime
+        // does not update Application.Current.RequestedTheme either, exactly as for every other window
+        private void ApplyWindowsTheme()
         {
             if (this.Content is FrameworkElement rootElement)
             {
-                rootElement.RequestedTheme = themeTag switch
-                {
-                    "Light" => ElementTheme.Light,
-                    "Dark" => ElementTheme.Dark,
-                    _ => ElementTheme.Default
-                };
+                rootElement.RequestedTheme = ElementTheme.Default;
             }
+
             UpdateVisualState();
         }
 


### PR DESCRIPTION
## What does this change

The taskbar widget sits inside the Windows taskbar, so it now follows the Windows theme
instead of the app theme setting. Every other window keeps following the setting.

Its sensor panels resolve their value text color from their own `ActualTheme` rather than
from the app theme setting, since the taskbar widget and the taskbar flyout render the same
view models while sitting on different themes.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English