### PR TITLE
Add a setting to switch graphs between stepline and smooth

### DIFF
--- a/FluentSensors/Common/Sensors/GraphLineStyle.cs
+++ b/FluentSensors/Common/Sensors/GraphLineStyle.cs
@@ -1,0 +1,9 @@
+namespace FluentSensors.Common.Sensors
+{
+    // how a sensor graph draws the line between data points
+    public enum GraphLineStyle
+    {
+        Stepline, // horizontal-then-vertical staircase
+        Smooth // rounded curve through the points
+    }
+}

--- a/FluentSensors/Controls/SensorGraph/SensorGraphControl.Rendering.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorGraphControl.Rendering.cs
@@ -1,4 +1,5 @@
 ﻿using LiveChartsCore.Drawing;
+using LiveChartsCore.Kernel.Sketches;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
 using Microsoft.UI.Xaml;
@@ -113,6 +114,9 @@ namespace FluentSensors.Controls.SensorGraph
         {
             if (_lineSeries == null) return; // guard: called before constructor finishes
 
+            // stroke and fill are the shared surface between the stepline and smooth series types
+            var line = (IStrokedAndFilled)_lineSeries;
+
             bool hasThreshold = ThresholdValue is not null;
             double yMax = hasThreshold ? ComputeCurrentYMax() : 0;
             bool hasAnyRun = hasThreshold && ComputeHasAnyRun();
@@ -126,12 +130,12 @@ namespace FluentSensors.Controls.SensorGraph
             // no threshold set: flat single-color line and area
             if (!hasThreshold)
             {
-                _lineSeries.Fill = new LinearGradientPaint(
+                line.Fill = new LinearGradientPaint(
                     new[] { accent.WithAlpha(38), accent.WithAlpha(38) },
                     new SKPoint(0.5f, 0),
                     new SKPoint(0.5f, 1));
 
-                _lineSeries.Stroke = new SolidColorPaint(accent.WithAlpha(204)) { StrokeThickness = 1 };
+                line.Stroke = new SolidColorPaint(accent.WithAlpha(204)) { StrokeThickness = 1 };
                 return;
             }
 
@@ -157,7 +161,7 @@ namespace FluentSensors.Controls.SensorGraph
                 bottomColor = threshold;
             }
 
-            _lineSeries.Stroke = new LinearGradientPaint(
+            line.Stroke = new LinearGradientPaint(
                 new[] { topColor.WithAlpha(204), topColor.WithAlpha(204), bottomColor.WithAlpha(204), bottomColor.WithAlpha(204) },
                 new SKPoint(0.5f, 0),
                 new SKPoint(0.5f, 1),
@@ -174,7 +178,7 @@ namespace FluentSensors.Controls.SensorGraph
             if (runs.Count == 0 || Values is null || Values.Count == 0)
             {
                 // no alarm zones right now: flat area color
-                _lineSeries.Fill = new LinearGradientPaint(
+                line.Fill = new LinearGradientPaint(
                     new[] { accent.WithAlpha(38), accent.WithAlpha(38) },
                     new SKPoint(0.5f, 0),
                     new SKPoint(0.5f, 1));
@@ -218,7 +222,7 @@ namespace FluentSensors.Controls.SensorGraph
             colorArr[stopIdx] = accent.WithAlpha(38);
             stopArr[stopIdx] = 1f;
 
-            _lineSeries.Fill = new LinearGradientPaint(
+            line.Fill = new LinearGradientPaint(
                 colorArr,
                 new SKPoint(0, 0.5f), // horizontal gradient: left -> right
                 new SKPoint(1, 0.5f),

--- a/FluentSensors/Controls/SensorGraph/SensorGraphControl.xaml.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorGraphControl.xaml.cs
@@ -33,7 +33,13 @@ namespace FluentSensors.Controls.SensorGraph
         private readonly Axis _yAxis;
         private readonly Axis _xAxis;
         private readonly SolidColorPaint _crosshairPaint;
-        private readonly StepLineSeries<double?> _lineSeries;
+
+        // the staircase look is not drawn by hand, it is entirely the StepLineSeries type; a smooth line is a
+        // different type (LineSeries with LineSmoothness > 0), so switching style swaps the series object
+        // both are built once, only one is bound to the chart at a time (see ApplyLineStyle)
+        private readonly StepLineSeries<double?> _stepSeries;
+        private readonly LineSeries<double?> _smoothSeries;
+        private ISeries _lineSeries; // whichever of the two is active right now
         private bool _isPointerOverChart = false;
         private Windows.Foundation.Point _lastPointerPosition;
         private readonly DispatcherTimer _thresholdLabelTimer;
@@ -76,13 +82,21 @@ namespace FluentSensors.Controls.SensorGraph
             // starts rendering-active by default (see _isRenderingActive above), counted immediately
             _activeRenderingCount++;
 
-            // the LiveCharts ISeries definition
-            _lineSeries = new StepLineSeries<double?>
+            // the two LiveCharts series; stepline is the default, smooth is swapped in on demand (see ApplyLineStyle)
+            _stepSeries = new StepLineSeries<double?>
             {
                 Values = new ObservableCollection<double?>(),
                 GeometrySize = 0,
                 DataPadding = new LvcPoint(0, 0)
             };
+            _smoothSeries = new LineSeries<double?>
+            {
+                Values = new ObservableCollection<double?>(),
+                GeometrySize = 0,
+                DataPadding = new LvcPoint(0, 0),
+                LineSmoothness = 1.00 // livecharts default; 0 is straight segments, 1 is the most curved
+            };
+            _lineSeries = _stepSeries;
             Series = new ISeries[] { _lineSeries };
 
             // the LiveCharts y-axis definition
@@ -248,6 +262,23 @@ namespace FluentSensors.Controls.SensorGraph
             _lineSeries.Values = _detachedValues;
         }
 
+        // swaps the active series between stepline and smooth, keeping it pointed at the same data and forcing one
+        // repaint; the ApplyStroke paint guard would otherwise see an unchanged signature and leave the freshly
+        // swapped-in series with no stroke or fill
+        private void ApplyLineStyle()
+        {
+            ISeries target = LineStyle == GraphLineStyle.Smooth ? _smoothSeries : _stepSeries;
+            if (ReferenceEquals(target, _lineSeries)) return;
+
+            _lineSeries = target;
+            _lineSeries.Values = _isValuesSubscribed && _boundValues != null ? _boundValues : _detachedValues;
+
+            // Chart.Series is set once from the {Binding Series} in xaml; from here on it is driven imperatively,
+            // same as Chart.Sections in RebuildSections
+            Chart.Series = new ISeries[] { _lineSeries };
+            ForceRepaint();
+        }
+
 
         // DependencyProperty: AccentColor
         public Windows.UI.Color AccentColor
@@ -268,6 +299,28 @@ namespace FluentSensors.Controls.SensorGraph
             {
                 g.ApplyStroke();
             }
+        }
+
+
+        // DependencyProperty: LineStyle
+        // stepline (staircase) or smooth (curved); global setting, flows in from SensorPanelControl via
+        // SensorGraphViewModel.GraphLineStyle
+        public GraphLineStyle LineStyle
+        {
+            get => (GraphLineStyle)GetValue(LineStyleProperty);
+            set => SetValue(LineStyleProperty, value);
+        }
+
+        public static readonly DependencyProperty LineStyleProperty =
+            DependencyProperty.Register(
+                nameof(LineStyle),
+                typeof(GraphLineStyle),
+                typeof(SensorGraphControl),
+                new PropertyMetadata(GraphLineStyle.Stepline, OnLineStyleChanged));
+
+        private static void OnLineStyleChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is SensorGraphControl g) g.ApplyLineStyle();
         }
 
 

--- a/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
+++ b/FluentSensors/Controls/SensorGraph/SensorGraphViewModel.cs
@@ -64,8 +64,12 @@ namespace FluentSensors.Controls.SensorGraph
                 SettingsService.Instance.GraphTimeSpanChanged += OnGraphTimeSpanChanged;
             }
 
+            // line style is global; resolved and subscribed the same way for every scope
+            GraphLineStyle = SettingsService.Instance.GraphLineStyle;
+
             HardwareMonitorService.Instance.UpdateIntervalChanged += OnUpdateIntervalChanged;
             SettingsService.Instance.ThemeChanged += OnThemeChanged;
+            SettingsService.Instance.GraphLineStyleChanged += OnGraphLineStyleChanged;
 
             // owns this sensors threshold config; shared logic/state lives there, this VM only reacts to it for coloring
             Threshold = new ThresholdEditorViewModel(sensorId, sensorType);
@@ -122,6 +126,15 @@ namespace FluentSensors.Controls.SensorGraph
         {
             get => _graphColor;
             private set { _graphColor = value; OnPropertyChanged(); }
+        }
+
+        // stepline vs smooth; mirrors the global SettingsService switch, same event -> property -> x:Bind path
+        // as GraphColor above
+        private GraphLineStyle _graphLineStyle;
+        public GraphLineStyle GraphLineStyle
+        {
+            get => _graphLineStyle;
+            private set { _graphLineStyle = value; OnPropertyChanged(); }
         }
 
         // taskbar widget graphs can drop their calculated card tint and go fully transparent
@@ -244,6 +257,11 @@ namespace FluentSensors.Controls.SensorGraph
             GraphColor = ResolveGraphColor(useAccent, customColor);
         }
 
+        private void OnGraphLineStyleChanged(GraphLineStyle style)
+        {
+            GraphLineStyle = style;
+        }
+
         private void OnGraphBackgroundChanged(bool useTransparentBackground)
         {
             IsCardBackgroundVisible = !useTransparentBackground;
@@ -294,6 +312,7 @@ namespace FluentSensors.Controls.SensorGraph
 
             HardwareMonitorService.Instance.UpdateIntervalChanged -= OnUpdateIntervalChanged;
             SettingsService.Instance.ThemeChanged -= OnThemeChanged;
+            SettingsService.Instance.GraphLineStyleChanged -= OnGraphLineStyleChanged;
             Threshold.PropertyChanged -= OnThresholdPropertyChanged;
             Threshold.Cleanup();
         }

--- a/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml
+++ b/FluentSensors/Controls/SensorGraph/SensorPanelControl.xaml
@@ -377,6 +377,7 @@
                     IsNameVisible="{x:Bind ShowGraphName, Mode=OneWay}"
                     LabelFollowsPointer="True"
                     LabelText="{x:Bind ViewModel.SensorName, Mode=OneWay}"
+                    LineStyle="{x:Bind ViewModel.GraphLineStyle, Mode=OneWay}"
                     ManualYMax="{x:Bind ViewModel.ManualYMax, Mode=OneWay}"
                     SensorType="{x:Bind ViewModel.SensorType, Mode=OneWay}"
                     Tapped="GraphControl_Tapped"

--- a/FluentSensors/Features/Settings/SettingsPage.xaml
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml
@@ -52,10 +52,29 @@
                     Width="150"
                     SelectionChanged="IntervalComboBox_SelectionChanged">
                     <ComboBoxItem Content="100ms" Tag="100" />
+                    <ComboBoxItem Content="150ms" Tag="150" />
+                    <ComboBoxItem Content="200ms" Tag="200" />
                     <ComboBoxItem Content="250ms" Tag="250" />
+                    <ComboBoxItem Content="300ms" Tag="300" />
+                    <ComboBoxItem Content="400ms" Tag="400" />
                     <ComboBoxItem Content="500ms" Tag="500" />
                     <ComboBoxItem Content="1000ms" Tag="1000" />
                     <ComboBoxItem Content="2000ms" Tag="2000" />
+                    <ComboBoxItem Content="5000ms" Tag="5000" />
+                </ComboBox>
+            </controls:SettingsCard>
+
+            <!--  graph line style: applies to every graph in the app  -->
+            <controls:SettingsCard
+                Description="Staircase steps or a rounded curve between data points"
+                Header="Graph Line Style"
+                HeaderIcon="{toolkit:FontIcon Glyph=&#xE9D2;}">
+                <ComboBox
+                    x:Name="GraphLineStyleComboBox"
+                    Width="150"
+                    SelectionChanged="GraphLineStyleComboBox_SelectionChanged">
+                    <ComboBoxItem Content="Stepline" Tag="Stepline" />
+                    <ComboBoxItem Content="Smooth" Tag="Smooth" />
                 </ComboBox>
             </controls:SettingsCard>
 

--- a/FluentSensors/Features/Settings/SettingsPage.xaml.cs
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using FluentSensors.Persistence.Services;
 using FluentSensors.Persistence.Models;
 using FluentSensors.Core;
+using FluentSensors.Common.Sensors;
 
 
 namespace FluentSensors.Features.Settings
@@ -31,6 +32,7 @@ namespace FluentSensors.Features.Settings
             RestoreThemeSelection();
             RestoreIntervalSelection();
             RestoreMinimizeToTraySelection();
+            RestoreGraphLineStyleSelection();
 
             RestoreBackgroundMaterialSettings();
             RestoreGraphColorSettings();
@@ -153,6 +155,32 @@ namespace FluentSensors.Features.Settings
         private void RestoreMinimizeToTraySelection()
         {
             MinimizeToTrayToggle.IsOn = SettingsService.Instance.MinimizeToTray;
+        }
+
+        // graph line style (stepline / smooth), one global switch for every graph
+        private void GraphLineStyleComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+
+            if (GraphLineStyleComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tag
+                && Enum.TryParse(tag, out GraphLineStyle style))
+            {
+                SettingsService.Instance.GraphLineStyle = style;
+            }
+        }
+
+        private void RestoreGraphLineStyleSelection()
+        {
+            string current = SettingsService.Instance.GraphLineStyle.ToString();
+
+            foreach (ComboBoxItem item in GraphLineStyleComboBox.Items)
+            {
+                if (item.Tag?.ToString() == current)
+                {
+                    GraphLineStyleComboBox.SelectedItem = item;
+                    break;
+                }
+            }
         }
 
 

--- a/FluentSensors/Persistence/Models/AppSettingsData.cs
+++ b/FluentSensors/Persistence/Models/AppSettingsData.cs
@@ -1,5 +1,7 @@
 using Windows.UI;
 
+using FluentSensors.Common.Sensors;
+
 
 namespace FluentSensors.Persistence.Models
 {
@@ -19,6 +21,9 @@ namespace FluentSensors.Persistence.Models
         public bool UseGraphAccentColor { get; set; } = true;
         public Windows.UI.Color GraphCustomColor { get; set; } = Microsoft.UI.Colors.LightBlue;
         public double GraphTimeSpanSeconds { get; set; } = 45;
+
+        // stepline or smooth line rendering; global, applies to every graph in the app
+        public GraphLineStyle GraphLineStyle { get; set; } = GraphLineStyle.Stepline;
 
         // taskbar ecosystem (taskbar widget + flyout window) appearance
         public string TaskbarBackdropType { get; set; } = "Mica";

--- a/FluentSensors/Persistence/Services/SettingsService.cs
+++ b/FluentSensors/Persistence/Services/SettingsService.cs
@@ -3,6 +3,7 @@ using Windows.UI;
 
 using FluentSensors.Persistence.Models;
 using FluentSensors.Core;
+using FluentSensors.Common.Sensors;
 
 
 namespace FluentSensors.Persistence.Services
@@ -156,6 +157,22 @@ namespace FluentSensors.Persistence.Services
                 {
                     _graphTimeSpanSeconds = value;
                     GraphTimeSpanChanged?.Invoke(_graphTimeSpanSeconds);
+                    SaveDebounced();
+                }
+            }
+        }
+
+        // stepline or smooth line rendering; one global switch for every graph, regardless of scope
+        private GraphLineStyle _graphLineStyle = GraphLineStyle.Stepline;
+        public GraphLineStyle GraphLineStyle
+        {
+            get => _graphLineStyle;
+            set
+            {
+                if (_graphLineStyle != value)
+                {
+                    _graphLineStyle = value;
+                    GraphLineStyleChanged?.Invoke(_graphLineStyle);
                     SaveDebounced();
                 }
             }
@@ -410,6 +427,7 @@ namespace FluentSensors.Persistence.Services
             _useGraphAccentColor = data.UseGraphAccentColor;
             _graphCustomColor = data.GraphCustomColor;
             _graphTimeSpanSeconds = data.GraphTimeSpanSeconds;
+            _graphLineStyle = data.GraphLineStyle;
 
             _taskbarBackdropType = data.TaskbarBackdropType;
             _taskbarTintOpacity = data.TaskbarTintOpacity;
@@ -446,6 +464,7 @@ namespace FluentSensors.Persistence.Services
                 UseGraphAccentColor = _useGraphAccentColor,
                 GraphCustomColor = _graphCustomColor,
                 GraphTimeSpanSeconds = _graphTimeSpanSeconds,
+                GraphLineStyle = _graphLineStyle,
 
                 TaskbarBackdropType = _taskbarBackdropType,
                 TaskbarTintOpacity = _taskbarTintOpacity,
@@ -492,6 +511,7 @@ namespace FluentSensors.Persistence.Services
         public event Action<bool, Color> TintColorChanged;
         public event Action<bool, Windows.UI.Color> GraphColorChanged;
         public event Action<double> GraphTimeSpanChanged;
+        public event Action<GraphLineStyle> GraphLineStyleChanged;
 
         public event Action<string> TaskbarBackdropTypeChanged;
         public event Action<float, float> TaskbarOpacityChanged;


### PR DESCRIPTION
## What does this change

New setting under General Settings to switch all graphs between stepline (default) and smooth curves. Applies live, no restart. Persisted, covered by reset.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English