### PR TITLE
Add a portable zip build alongside the installer

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -20,6 +20,17 @@ How it currently looks performance-wise:
 * **WinUI 3 memory leaks:** WinUI 3 has known platform-level memory leaks, for example [secondary windows not fully releasing after closing](https://github.com/microsoft/microsoft-ui-xaml/issues/9063). Fluent Sensors works around these by hiding and reusing windows instead of destroying them.
 * **General optimization:** WinUI 3 is not the fastest UI framework, so manual optimization work is ongoing.
 
+## 📦 Download
+
+Every release on the [releases page](https://github.com/cechout/fluent-sensors/releases) ships two x64 builds:
+
+* **Installer** (`FluentSensors_Installer.exe`): installs into `Program Files`, creates a start menu entry and an optional desktop shortcut, and registers an uninstall entry. Settings are stored in `%LocalAppData%\FluentHwInfo`.
+* **Portable** (`FluentSensors_Portable_<version>.zip`): unzip it anywhere and run `FluentSensors.exe`. No setup, no uninstall entry. Settings are stored in a `Persistence` folder next to the executable, so the whole folder can be moved between drives or machines, and deleting it removes every trace of the app.
+
+Both builds come from the same compilation and differ only in the `portable.txt` marker file, which is what switches the storage location.
+
+Please note that both builds require administrator rights. Reading hardware sensors relies on a kernel level driver that LibreHardwareMonitorLib registers on startup and removes again on exit. "Portable" here means no setup and no leftover configuration, it does not mean the app runs without elevation.
+
 ## 🛠️ How to Build
 
 ### 1. Prerequisites

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# builds the win-x64 installer and drafts a GitHub release whenever a version tag is pushed
+# builds the win-x64 installer plus the portable zip and drafts a GitHub release whenever a version tag is pushed
 # csproj Version is the single source of truth, Inno Setup receives it as a command line define
 name: release
 
@@ -63,11 +63,29 @@ jobs:
           /DMyAppVersion=${{ steps.version.outputs.version }}
           Setup\Inno_Setup.iss
 
+      # portable variant: the exact same publish output the installer just consumed, staged into its own folder and
+      # given the marker file that makes the app store its settings next to the exe instead of in %LocalAppData%
+      # staged instead of zipped in place so the marker can never end up in the installer payload
+      - name: package portable zip
+        shell: pwsh
+        run: |
+          $staging = "Setup/Output/FluentSensors_Portable_${{ steps.version.outputs.version }}"
+          New-Item -ItemType Directory -Force -Path $staging | Out-Null
+          Copy-Item -Path "FluentSensors/bin/x64/Release/net10.0-windows10.0.19041.0/publish/win-x64/*" -Destination $staging -Recurse -Force
+          Copy-Item -Path "Setup/Portable/portable.txt" -Destination $staging -Force
+          Compress-Archive -Path $staging -DestinationPath "$staging.zip" -Force
+
       - name: upload installer artifact
         uses: actions/upload-artifact@v7
         with:
           name: FluentSensors_Installer
           path: Setup/Output/FluentSensors_Installer.exe
+
+      - name: upload portable artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: FluentSensors_Portable
+          path: Setup/Output/FluentSensors_Portable_${{ steps.version.outputs.version }}.zip
 
       # create draft only
       - name: create draft release
@@ -76,4 +94,5 @@ jobs:
         run: >
           gh release create ${{ github.ref_name }}
           Setup/Output/FluentSensors_Installer.exe
+          Setup/Output/FluentSensors_Portable_${{ steps.version.outputs.version }}.zip
           --draft --generate-notes --title "FluentSensors ${{ github.ref_name }}"

--- a/FluentSensors/Persistence/Services/PersistenceService.cs
+++ b/FluentSensors/Persistence/Services/PersistenceService.cs
@@ -19,8 +19,13 @@ namespace FluentSensors.Persistence.Services
     {
         // === fields ===
 
-        private readonly string _rootFolder = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "FluentHwInfo");
+        // portable mode: a marker file next to the exe moves persistence from %LocalAppData% into the app folder,
+        // so a portable copy carries its state on the drive it runs from and leaves nothing behind on the host
+        // the marker ships only in the portable zip, installer builds never contain it
+        private const string PortableMarkerFileName = "portable.txt";
+        private const string PortableFolderName = "Persistence";
+
+        private readonly string _rootFolder = ResolveRootFolder();
         private string SettingsPath => Path.Combine(_rootFolder, "settings.json");
         private string WindowStatePath => Path.Combine(_rootFolder, "window-state.json");
         private string SensorStatePath => Path.Combine(_rootFolder, "sensors.json");
@@ -252,6 +257,33 @@ namespace FluentSensors.Persistence.Services
 
 
         // === private helpers ===
+
+        // decides once at startup where the five json files live; portable builds are detected by the marker file
+        // rather than by a user setting, because such a setting would itself need a location to be stored in
+        private static string ResolveRootFolder()
+        {
+            string localAppData = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "FluentHwInfo");
+
+            try
+            {
+                string? appFolder = Path.GetDirectoryName(Environment.ProcessPath);
+                if (string.IsNullOrEmpty(appFolder)) return localAppData;
+                if (!File.Exists(Path.Combine(appFolder, PortableMarkerFileName))) return localAppData;
+
+                // creating the folder here doubles as an early check that the app directory is writable at all;
+                // an unpacked zip sitting in a read-only location would otherwise silently drop every save
+                string portableFolder = Path.Combine(appFolder, PortableFolderName);
+                Directory.CreateDirectory(portableFolder);
+                return portableFolder;
+            }
+            catch
+            {
+                // unreadable app folder, or one that cannot be created: fall back to the per-user location instead
+                // of losing state
+                return localAppData;
+            }
+        }
 
         private void ResetTimer(ref Timer timer, Action save)
         {

--- a/Setup/Inno_Setup.iss
+++ b/Setup/Inno_Setup.iss
@@ -52,7 +52,9 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "..\FluentSensors\bin\x64\Release\net10.0-windows10.0.19041.0\publish\win-x64\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
-Source: "..\FluentSensors\bin\x64\Release\net10.0-windows10.0.19041.0\publish\win-x64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+; Excludes keeps a locally created portable marker and its Persistence folder out of the installer, so an
+; installed build can never end up writing its settings into Program Files
+Source: "..\FluentSensors\bin\x64\Release\net10.0-windows10.0.19041.0\publish\win-x64\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "\portable.txt,\Persistence"
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]

--- a/Setup/Portable/portable.txt
+++ b/Setup/Portable/portable.txt
@@ -1,0 +1,15 @@
+Fluent Sensors - portable mode
+==============================
+
+As long as this file sits next to FluentSensors.exe, the app keeps all of its settings in the
+"Persistence" folder inside this directory instead of %LocalAppData%\FluentHwInfo.
+
+That means you can move or copy this folder to another drive or machine and your sensor
+selections, window positions and settings travel with it. Deleting the folder removes every
+trace of the app. Delete just this file if you want this copy to use the normal per-user
+location instead.
+
+Please note: Fluent Sensors still requires administrator rights, and it still loads a kernel
+level driver (through LibreHardwareMonitorLib) to read your hardware sensors. That driver is
+registered when the app starts and removed again when it exits. Portable here means "no setup
+and no leftover configuration", it does not mean the app runs without elevation.


### PR DESCRIPTION
## What does this change

Adds a portable build so the app can be run from a folder without installing it. Part of #48.

- `PersistenceService` resolves its storage location once at startup: if a `portable.txt` sits next to the exe, state goes into `<appdir>\Persistence`, otherwise it stays in `%LocalAppData%\FluentHwInfo`. Falls back to the per-user path if the app folder is not writable.
- Detection is a marker file, not a setting, because such a setting would itself need a location to be stored in.
- `release.yml` stages the same publish output the installer consumes, adds the marker and ships `FluentSensors_Portable_<version>.zip` next to the installer on the draft release.
- `Inno_Setup.iss` excludes `portable.txt` and `Persistence` so a locally created marker can never end up in an installed build.
- README gets a short download section covering both variants.

Both artifacts come from one compilation and differ only by the marker file. Portable still requires administrator rights, since the sensor driver is loaded either way; that is stated in the marker file and the README.

**Testing**

Built and format-checked locally, packaging step run end to end (117.9 MB zip, correct layout). Portable copy started manually: `Persistence` folder is created next to the exe and `%LocalAppData%\FluentHwInfo` stays untouched.