### PR TITLE
Slim down the published app  by 60 MB

### DIFF
--- a/FluentSensors/FluentSensors.csproj
+++ b/FluentSensors/FluentSensors.csproj
@@ -239,8 +239,10 @@
   <PropertyGroup>
     <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
     <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
-    <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
-    <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
+    <!--
+      PublishTrimmed stays unset on purpose, trimming strips the WinRT and COM interop types this app needs
+      and the published build then crashes on startup
+    -->
   </PropertyGroup>
   <!--
     the self contained publish carries binaries this app never loads

--- a/FluentSensors/FluentSensors.csproj
+++ b/FluentSensors/FluentSensors.csproj
@@ -246,13 +246,20 @@
   </PropertyGroup>
   <!--
     the self contained publish carries binaries this app never loads
-    the mui files are WinUI system strings for 83 languages while this UI is english only, the
-    mscordaccore/mscordbi/DiaSymReader set is only ever pulled in by an attached debugger or a dump reader,
-    clrgc and clrgcexp are alternative collectors that stay dormant unless System.GC.Name is set in the
-    runtimeconfig, msquic is HTTP/3, and Mono.Posix is the linux sensor path inside LibreHardwareMonitorLib
+    the mscordaccore/mscordbi/DiaSymReader set is only ever pulled in by an attached debugger or a dump
+    reader, clrgc and clrgcexp are alternative collectors that stay dormant unless System.GC.Name is set in
+    the runtimeconfig, msquic is HTTP/3, and Mono.Posix is the linux sensor path inside
+    LibreHardwareMonitorLib
     the pdb is dropped here instead of suppressed via DebugType so the symbols still sit next to the build
     for local triage
     this runs after Publish, so the installer and the portable zip both pick up the smaller payload
+
+    do NOT add the mui locale folders here, they look like translations for 83 languages this app does not
+    offer, but Microsoft.ui.xaml.dll keeps its resources only in those mui files with no neutral copy inside
+    the dll, so the resource load fails as soon as the visual tree is built and the process dies with
+    STATUS_STOWED_EXCEPTION (0xc000027b) in Microsoft.UI.Xaml.dll
+    the folder that gets loaded is the one matching the Windows UI language, so trimming this down to en-US
+    breaks every machine that is not running english
   -->
   <Target Name="PruneUnusedPublishPayload" AfterTargets="Publish">
     <ItemGroup>
@@ -274,11 +281,7 @@
         dependencies it declares, and nothing else in the graph references it
       -->
       <_PrunedPublishFile Include="$(PublishDir)System.Numerics.Tensors.dll" />
-      <!--  a locale folder is recognised by the mui files it holds, so new languages need no list update  -->
-      <_PrunedPublishMui Include="$(PublishDir)*\*.mui" />
-      <_PrunedPublishLocaleDir Include="@(_PrunedPublishMui->'%(RootDir)%(Directory)')" />
     </ItemGroup>
     <Delete Files="@(_PrunedPublishFile)" />
-    <RemoveDir Directories="@(_PrunedPublishLocaleDir)" />
   </Target>
 </Project>

--- a/FluentSensors/FluentSensors.csproj
+++ b/FluentSensors/FluentSensors.csproj
@@ -89,6 +89,22 @@
     <PackageReference Include="LiveChartsCore.SkiaSharpView.WinUI" Version="2.0.5" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+    <!--
+      the metapackage drags in the AI, ML and widgets components, and this app calls none of their APIs
+      each component also contributes an appxfragment that declares regfree WinRT activatable classes into
+      the generated app manifest, so deleting the binaries alone would leave the manifest pointing at files
+      that are gone, which can fail the process start outright
+      excluding all assets keeps the component props out of the build, so payload and manifest entries drop
+      together
+    -->
+    <PackageReference Include="Microsoft.WindowsAppSDK.AI" Version="2.2.3" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.ML" Version="2.1.70" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.Widgets" Version="2.0.5" ExcludeAssets="all" />
+    <!--
+      onnxruntime and DirectML ride in transitively through the ML component, and excluding a package does
+      not prune its dependency graph, so this one has to be named on its own
+    -->
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" Version="2.1.70" ExcludeAssets="all" />
     <PackageReference Include="System.Management" Version="10.0.10" />
     <PackageReference Include="Vortice.DXGI" Version="3.8.3" />
     <PackageReference Include="WinUIEx" Version="2.9.2" />

--- a/FluentSensors/FluentSensors.csproj
+++ b/FluentSensors/FluentSensors.csproj
@@ -242,4 +242,41 @@
     <PublishTrimmed Condition="'$(Configuration)' == 'Debug'">False</PublishTrimmed>
     <PublishTrimmed Condition="'$(Configuration)' != 'Debug'">True</PublishTrimmed>
   </PropertyGroup>
+  <!--
+    the self contained publish carries binaries this app never loads
+    the mui files are WinUI system strings for 83 languages while this UI is english only, the
+    mscordaccore/mscordbi/DiaSymReader set is only ever pulled in by an attached debugger or a dump reader,
+    clrgc and clrgcexp are alternative collectors that stay dormant unless System.GC.Name is set in the
+    runtimeconfig, msquic is HTTP/3, and Mono.Posix is the linux sensor path inside LibreHardwareMonitorLib
+    the pdb is dropped here instead of suppressed via DebugType so the symbols still sit next to the build
+    for local triage
+    this runs after Publish, so the installer and the portable zip both pick up the smaller payload
+  -->
+  <Target Name="PruneUnusedPublishPayload" AfterTargets="Publish">
+    <ItemGroup>
+      <_PrunedPublishFile Include="$(PublishDir)FluentSensors.pdb" />
+      <_PrunedPublishFile Include="$(PublishDir)Mono.Posix.NETStandard.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)libMonoPosixHelper.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)MonoPosixHelper.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)mscordaccore.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)mscordaccore_*.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)mscordbi.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)Microsoft.DiaSymReader.Native.amd64.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)createdump.exe" />
+      <_PrunedPublishFile Include="$(PublishDir)clretwrc.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)clrgc.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)clrgcexp.dll" />
+      <_PrunedPublishFile Include="$(PublishDir)msquic.dll" />
+      <!--
+        left behind by the excluded ML component, ExcludeAssets drops a package own assets but not the
+        dependencies it declares, and nothing else in the graph references it
+      -->
+      <_PrunedPublishFile Include="$(PublishDir)System.Numerics.Tensors.dll" />
+      <!--  a locale folder is recognised by the mui files it holds, so new languages need no list update  -->
+      <_PrunedPublishMui Include="$(PublishDir)*\*.mui" />
+      <_PrunedPublishLocaleDir Include="@(_PrunedPublishMui->'%(RootDir)%(Directory)')" />
+    </ItemGroup>
+    <Delete Files="@(_PrunedPublishFile)" />
+    <RemoveDir Directories="@(_PrunedPublishLocaleDir)" />
+  </Target>
 </Project>


### PR DESCRIPTION
## What does this change

The extracted app was ~300 MB. A file-by-file audit of the publish output showed a large
block belonging to features this app never calls, plus binaries only a debugger loads.

### What goes

- **Windows AI, ML and Widgets components (~50 MB)** — `onnxruntime.dll` (20.7 MB),
  `DirectML.dll` (17.8 MB), the AI natives and `Microsoft.Windows.Widgets.dll`. Nothing in
  the source references any of these APIs.
- **~10 MB of dead weight** — the `mscordaccore`/`mscordbi`/`DiaSymReader` debugger set,
  the dormant `clrgc`/`clrgcexp` collectors, `msquic`, `Mono.Posix` (LibreHardwareMonitorLib's
  Linux path) and the `.pdb`.

### What deliberately stays

ReadyToRun, in full. It accounts for ~51 MB of the output but buys startup speed, and this
app starts with Windows. Same for the .NET runtime, the WinUI core and SkiaSharp.

### Results

| | before | after |
| --- | ---: | ---: |
| Publish folder | 303.6 MB | **243.1 MB** |
| Portable zip | 123.7 MB | ~91 MB |
| Installer | 72.2 MB | ~62 MB |

### Why the components are deselected rather than deleted

Every Windows App SDK component ships an `appxfragment`, and the build generates the embedded
regfree WinRT manifest from those. Deleting the DLLs alone would leave the manifest declaring
activatable classes in files that are gone, which can fail the process start outright.
`ExcludeAssets="all"` drops fragment and payload together —from
26 to 16 entries and every remaining entry resolves to a file on disk.

Also removes a dead `PublishTrimmed=True` in the csproj. Itofile,
but any publish without that profile would have produced a trimmed, crashing build.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English