### PR TITLE
Let the Mica backdrop through the loading screen

### DIFF
--- a/FluentSensors/MainWindow.xaml
+++ b/FluentSensors/MainWindow.xaml
@@ -204,12 +204,19 @@
 
 
         <!--  navigation view  -->
+        <!--
+            invisible until loading finishes; the splash below is transparent now and would otherwise show the
+            pane through it
+            Opacity rather than Visibility on purpose: the reveal sequence closes the pane and waits for that to
+            settle, which needs the layout pass a collapsed element does not get
+        -->
         <NavigationView
             x:Name="MainNavigationView"
             Grid.Row="1"
             IsBackButtonVisible="Collapsed"
             IsPaneOpen="False"
             IsSettingsVisible="False"
+            Opacity="0"
             OpenPaneLength="170"
             PaneDisplayMode="Left"
             SelectionChanged="MainNavigationView_SelectionChanged">
@@ -251,7 +258,7 @@
             x:Name="SplashOverlay"
             Grid.Row="1"
             HorizontalAlignment="Stretch"
-            Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+            Background="Transparent">
 
             <StackPanel
                 HorizontalAlignment="Stretch"

--- a/FluentSensors/MainWindow.xaml.cs
+++ b/FluentSensors/MainWindow.xaml.cs
@@ -259,9 +259,6 @@ namespace FluentSensors
             LoadingStatusText.Text = "Ready";
             //await Task.Delay(100);
 
-            // show the main grid
-            MainNavigationView.Visibility = Visibility.Visible;
-
             // manually close navigation pane
             this.DispatcherQueue.TryEnqueue(() =>
             {
@@ -269,6 +266,8 @@ namespace FluentSensors
             });
             await Task.Delay(200);
 
+            // show the main grid, both in the same frame so the transparent splash never uncovers the pane
+            MainNavigationView.Opacity = 1;
             SplashOverlay.Visibility = Visibility.Collapsed;
             AppStatus.IsAppReady = true;
             AppStatus.IsDotNetRuntimeMissing = !WinStaticInfoService.Instance.IsDotNetRuntimeInstalled;


### PR DESCRIPTION
## What does this change

The splash overlay painted a solid background that covered the window's Mica backdrop; it is
transparent now, and the NavigationView behind it is gated until the splash collapses so its
pane does not show through.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English