### PR TITLE
Rework the taskbar widget button visual states

### DIFF
--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -24,28 +24,37 @@
                     <!--  Pressed -> Target #2A2A2A (42): Alpha 11 (0x0B) -> #0BFFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonPressedBackground" Color="#0BFFFFFF" />
 
-                    <!--  2. Taskbar Button Borders (Dark Mode: Only TOP border in Normal Hover, ALL 4 in Normal Pressed)  -->
-                    <!--  Normal Hover Border: Top #16FFFFFF (Target #333333), sides & bottom Transparent  -->
+                    <!--  2. Taskbar Button Borders (Dark Mode)  -->
+                    <!--  the border is never transparent: it carries the #16FFFFFF top highlight and the same fill
+                          brush on the sides & bottom, so it always paints its 1px (no size shift between states) but
+                          reads as invisible where it should; #0FFFFFFF over #202020 == the hover fill  -->
                     <LinearGradientBrush x:Key="TaskbarButtonBorderBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientStop Offset="0.0" Color="#16FFFFFF" />
-                        <GradientStop Offset="0.10" Color="Transparent" />
-                        <GradientStop Offset="1.0" Color="Transparent" />
+                        <GradientStop Offset="0.10" Color="#0FFFFFFF" />
+                        <GradientStop Offset="1.0" Color="#0FFFFFFF" />
                     </LinearGradientBrush>
-                    <!--  Normal Pressed Border: All 4 borders visible with #0AFFFFFF (Target #292929 on sides/bottom)  -->
-                    <SolidColorBrush x:Key="TaskbarButtonPressedBorderBrush" Color="#0AFFFFFF" />
+                    <!--  Normal Pressed Border: sole source of the pressed border (StrokeBorder is off in this state),
+                          so the top stop is self-sufficient at #1FFFFFFF -> #3B3B3B; sides & bottom #10FFFFFF -> #2E2E2E  -->
+                    <LinearGradientBrush x:Key="TaskbarButtonPressedBorderBrush" StartPoint="0,0" EndPoint="0,1">
+                        <GradientStop Offset="0.0" Color="#1FFFFFFF" />
+                        <GradientStop Offset="0.12" Color="#10FFFFFF" />
+                        <GradientStop Offset="1.0" Color="#10FFFFFF" />
+                    </LinearGradientBrush>
 
                     <!--  3. Active Flyout State (When Flyout is currently OPEN)  -->
                     <!--  Active Hover -> Target #323232 (50): Alpha 21 (0x15) -> #15FFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonActiveHoverBackground" Color="#15FFFFFF" />
-                    <!--  Active Hover Border: Keep top border #16FFFFFF, sides & bottom Transparent  -->
+                    <!--  Active Hover Border: #16FFFFFF top highlight, active-hover fill brush on sides & bottom
+                          (#15FFFFFF over #202020 == the active-hover fill, so the 1px reads as invisible)  -->
                     <LinearGradientBrush x:Key="TaskbarButtonActiveHoverBorderBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientStop Offset="0.0" Color="#16FFFFFF" />
-                        <GradientStop Offset="0.10" Color="Transparent" />
-                        <GradientStop Offset="1.0" Color="Transparent" />
+                        <GradientStop Offset="0.10" Color="#15FFFFFF" />
+                        <GradientStop Offset="1.0" Color="#15FFFFFF" />
                     </LinearGradientBrush>
                     <!--  Active Pressed -> Target #2A2A2A (42): Alpha 11 (0x0B) -> #0BFFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBackground" Color="#0BFFFFFF" />
-                    <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="Transparent" />
+                    <!--  no visible border in this state, so it takes the fill brush (never Transparent) and paints its 1px  -->
+                    <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="#0BFFFFFF" />
 
                     <!--  4. Flyout Window Styling (Dark Mode)  -->
                     <!--
@@ -91,30 +100,38 @@
                     <!--  Pressed -> Target #F3F3F3 (243): Alpha 85 (0x55) -> #55FFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonPressedBackground" Color="#55FFFFFF" />
 
-                    <!--  2. Taskbar Button Border (Solid: Normal Hover & Pressed)  -->
-                    <!--  Top & Sides: #E7E7E7, Bottom: #DDDDDD  -->
+                    <!--  2. Taskbar Button Border (Normal Hover & Pressed)  -->
+                    <!--  alpha black so it tracks the bar; calibrated against the transparency-on light taskbar (~#F0F0F0)
+                          to land top & sides #E7E7E7, bottom #DDDDDD there; over the #EDEDED solid bar it reads ~2 levels darker  -->
                     <LinearGradientBrush x:Key="TaskbarButtonBorderBrush" StartPoint="0,0" EndPoint="0,1">
-                        <GradientStop Offset="0.0" Color="#E7E7E7" />
-                        <GradientStop Offset="0.75" Color="#E7E7E7" />
-                        <GradientStop Offset="1.0" Color="#DDDDDD" />
+                        <GradientStop Offset="0.0" Color="#0A000000" />
+                        <GradientStop Offset="0.75" Color="#0A000000" />
+                        <GradientStop Offset="1.0" Color="#14000000" />
                     </LinearGradientBrush>
-                    <!--  Normal Pressed Border: Transparent (StrokeBorder already covers it)  -->
-                    <SolidColorBrush x:Key="TaskbarButtonPressedBorderBrush" Color="Transparent" />
+                    <!--  Normal Pressed Border: sole source of the pressed border now (StrokeBorder is off in this state),
+                          same alpha-black values as TaskbarButtonBorderBrush -> top & sides #E7E7E7, bottom #DDDDDD  -->
+                    <LinearGradientBrush x:Key="TaskbarButtonPressedBorderBrush" StartPoint="0,0" EndPoint="0,1">
+                        <GradientStop Offset="0.0" Color="#0A000000" />
+                        <GradientStop Offset="0.75" Color="#0A000000" />
+                        <GradientStop Offset="1.0" Color="#14000000" />
+                    </LinearGradientBrush>
 
                     <!--  3. Active Flyout State (When Flyout is currently OPEN)  -->
                     <!--  Active Hover -> Target #FAFAFA (250): Alpha 184 (0xB8) -> #B8FFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonActiveHoverBackground" Color="#B8FFFFFF" />
-                    <!--  Active Hover Border (Solid) -> Top & Sides: #E5E5E5, Bottom: #D4D4D4  -->
+                    <!--  Active Hover Border: alpha black, calibrated against the transparency-on light taskbar (~#F0F0F0)
+                          to land top & sides #E5E5E5, bottom #D4D4D4 there  -->
                     <LinearGradientBrush x:Key="TaskbarButtonActiveHoverBorderBrush" StartPoint="0,0" EndPoint="0,1">
-                        <GradientStop Offset="0.0" Color="#E5E5E5" />
-                        <GradientStop Offset="0.75" Color="#E5E5E5" />
-                        <GradientStop Offset="1.0" Color="#D4D4D4" />
+                        <GradientStop Offset="0.0" Color="#0C000000" />
+                        <GradientStop Offset="0.75" Color="#0C000000" />
+                        <GradientStop Offset="1.0" Color="#1E000000" />
                     </LinearGradientBrush>
 
                     <!--  Active Pressed -> Target #F3F3F3 (243): Alpha 85 (0x55) -> #55FFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBackground" Color="#55FFFFFF" />
-                    <!--  Active Pressed Border (Solid) -> #E7E7E7 on all 4 sides  -->
-                    <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="#E7E7E7" />
+                    <!--  Active Pressed Border: alpha black over the bare bar (the fill layer is inset like the others now),
+                          calibrated against the transparency-on light taskbar (~#F0F0F0) to land #E7E7E7 on all 4 sides  -->
+                    <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="#0A000000" />
 
                     <!--  4. Flyout Window Styling (Light Mode)  -->
                     <!--

--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -25,11 +25,13 @@
                     <SolidColorBrush x:Key="TaskbarButtonPressedBackground" Color="#0BFFFFFF" />
 
                     <!--  2. Taskbar Button Borders (Dark Mode)  -->
-                    <!--  the border is never transparent: it carries the #16FFFFFF top highlight and the same fill
+                    <!--  the border is never transparent: it carries the #1DFFFFFF top highlight and the same fill
                           brush on the sides & bottom, so it always paints its 1px (no size shift between states) but
-                          reads as invisible where it should; #0FFFFFFF over #202020 == the hover fill  -->
+                          reads as invisible where it should; #0FFFFFFF over #202020 == the hover fill
+                          top stop is #1D (not #16): the stroke composites over the bare bar now that the fill is
+                          inset, so it needs the higher alpha to land ~#404040 and match the native taskbar highlight  -->
                     <LinearGradientBrush x:Key="TaskbarButtonBorderBrush" StartPoint="0,0" EndPoint="0,1">
-                        <GradientStop Offset="0.0" Color="#16FFFFFF" />
+                        <GradientStop Offset="0.0" Color="#1DFFFFFF" />
                         <GradientStop Offset="0.10" Color="#0FFFFFFF" />
                         <GradientStop Offset="1.0" Color="#0FFFFFFF" />
                     </LinearGradientBrush>
@@ -44,10 +46,10 @@
                     <!--  3. Active Flyout State (When Flyout is currently OPEN)  -->
                     <!--  Active Hover -> Target #323232 (50): Alpha 21 (0x15) -> #15FFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonActiveHoverBackground" Color="#15FFFFFF" />
-                    <!--  Active Hover Border: #16FFFFFF top highlight, active-hover fill brush on sides & bottom
-                          (#15FFFFFF over #202020 == the active-hover fill, so the 1px reads as invisible)  -->
+                    <!--  Active Hover Border: same #1DFFFFFF top highlight as normal hover (~#404040, native match),
+                          active-hover fill brush on sides & bottom so the 1px there reads as invisible  -->
                     <LinearGradientBrush x:Key="TaskbarButtonActiveHoverBorderBrush" StartPoint="0,0" EndPoint="0,1">
-                        <GradientStop Offset="0.0" Color="#16FFFFFF" />
+                        <GradientStop Offset="0.0" Color="#1DFFFFFF" />
                         <GradientStop Offset="0.10" Color="#15FFFFFF" />
                         <GradientStop Offset="1.0" Color="#15FFFFFF" />
                     </LinearGradientBrush>

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -132,7 +132,7 @@ namespace FluentSensors.Features.TaskbarWidget
         public const int WindowSlideDistanceDip = 300;
 
         // animation duration in milliseconds
-        public const int EnterAnimationDurationMs = 260; // duration on open (move-in)
+        public const int EnterAnimationDurationMs = 240; // duration on open (move-in)
         public const int ExitAnimationDurationMs = 140;  // duration on close (move-out)
 
         // how far the two durations and the slide distance above follow the pinned sensor count: all three are

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml
@@ -33,9 +33,13 @@
                 <ControlTemplate TargetType="Button">
                     <Grid>
                         <!--  normal hover fill layer (animated via DirectComposition)  -->
+                        <!--  1px transparent inset, like PressedBorder, so the stroke layer above composites over the
+                              taskbar and not over this fill (otherwise the hover border reads far too light)  -->
                         <Border
                             x:Name="BackgroundBorder"
                             Background="{ThemeResource TaskbarButtonHoverBackground}"
+                            BorderBrush="Transparent"
+                            BorderThickness="1"
                             CornerRadius="4"
                             Opacity="0" />
 
@@ -49,16 +53,22 @@
                             Opacity="0" />
 
                         <!--  active flyout hover fill layer (#323232 on-screen, DWM compensated)  -->
+                        <!--  same 1px transparent inset as BackgroundBorder, keeps the stroke off this fill  -->
                         <Border
                             x:Name="ActiveHoverBorder"
                             Background="{ThemeResource TaskbarButtonActiveHoverBackground}"
+                            BorderBrush="Transparent"
+                            BorderThickness="1"
                             CornerRadius="4"
                             Opacity="0" />
 
                         <!--  active flyout pressed fill layer (#2a2a2a on-screen, DWM compensated)  -->
+                        <!--  same 1px transparent inset as the other fill layers, keeps the stroke off this fill  -->
                         <Border
                             x:Name="ActivePressedBorder"
                             Background="{ThemeResource TaskbarButtonActivePressedBackground}"
+                            BorderBrush="Transparent"
+                            BorderThickness="1"
                             CornerRadius="4"
                             Opacity="0" />
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml
@@ -44,10 +44,13 @@
                             Opacity="0" />
 
                         <!--  normal pressed fill overlay layer  -->
+                        <!--  fill only; the border moved to PressedStrokeBorder so the fill can crossfade in sync
+                              with the hover fill while the border still snaps (a gated fill on top of a fading fill
+                              double-paints and flashes bright for a few frames)  -->
                         <Border
                             x:Name="PressedBorder"
                             Background="{ThemeResource TaskbarButtonPressedBackground}"
-                            BorderBrush="{ThemeResource TaskbarButtonPressedBorderBrush}"
+                            BorderBrush="Transparent"
                             BorderThickness="1"
                             CornerRadius="4"
                             Opacity="0" />
@@ -72,10 +75,18 @@
                             CornerRadius="4"
                             Opacity="0" />
 
-                        <!--  border stroke layer for normal hover & pressed (animated via DirectComposition)  -->
+                        <!--  border stroke layer for normal hover (animated via DirectComposition)  -->
                         <Border
                             x:Name="StrokeBorder"
                             BorderBrush="{ThemeResource TaskbarButtonBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="4"
+                            Opacity="0" />
+
+                        <!--  border stroke layer for normal pressed (gated separately from PressedBorder's fill)  -->
+                        <Border
+                            x:Name="PressedStrokeBorder"
+                            BorderBrush="{ThemeResource TaskbarButtonPressedBorderBrush}"
                             BorderThickness="1"
                             CornerRadius="4"
                             Opacity="0" />

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -735,6 +735,7 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private Visual _backgroundVisual;
         private Visual _pressedVisual;
+        private Visual _pressedStrokeVisual;
         private Visual _activeHoverVisual;
         private Visual _activePressedVisual;
         private Visual _strokeVisual;
@@ -798,6 +799,7 @@ namespace FluentSensors.Features.TaskbarWidget
 
             var bgBorder = FindVisualChild<Border>(TaskbarButton, "BackgroundBorder");
             var pressedBorder = FindVisualChild<Border>(TaskbarButton, "PressedBorder");
+            var pressedStrokeBorder = FindVisualChild<Border>(TaskbarButton, "PressedStrokeBorder");
             var activeHoverBorder = FindVisualChild<Border>(TaskbarButton, "ActiveHoverBorder");
             var activePressedBorder = FindVisualChild<Border>(TaskbarButton, "ActivePressedBorder");
             var strokeBorder = FindVisualChild<Border>(TaskbarButton, "StrokeBorder");
@@ -813,6 +815,10 @@ namespace FluentSensors.Features.TaskbarWidget
             if (pressedBorder != null)
             {
                 _pressedVisual = ElementCompositionPreview.GetElementVisual(pressedBorder);
+            }
+            if (pressedStrokeBorder != null)
+            {
+                _pressedStrokeVisual = ElementCompositionPreview.GetElementVisual(pressedStrokeBorder);
             }
             if (activeHoverBorder != null)
             {
@@ -840,16 +846,28 @@ namespace FluentSensors.Features.TaskbarWidget
             }
         }
 
+        // previous engagement snapshot; the cross-state fades run only when this flips
+        private bool _wasEngaged;
+
         private void UpdateVisualState()
         {
             EnsureCompositionElements();
             if (_compositor == null) return;
 
+            // the border/stroke layers only fade when the button crosses the rest <-> engaged boundary; between
+            // engaged sub-states they snap, so no two 1px edges ever crossfade through the same tone and flicker
+            // the fill layers (and the content dim) always fade with their normal timing; a fill crossfade blends
+            // smoothly and does not flicker the way a hairline does
+            bool engaged = _isPointerOver || _isPressed || _isFlyoutActive;
+            bool animate = engaged != _wasEngaged;
+            _wasEngaged = engaged;
+            int Dur(int ms) => animate ? ms : 0;
+
             if (!_isFlyoutActive)
             {
                 // === Flyout Closed ===
-                AnimateVisualOpacity(_activeHoverStrokeVisual, 0.0f, ExitStrokeDurationMs);
-                AnimateVisualOpacity(_activePressedStrokeVisual, 0.0f, ExitStrokeDurationMs);
+                AnimateVisualOpacity(_activeHoverStrokeVisual, 0.0f, Dur(ExitStrokeDurationMs));
+                AnimateVisualOpacity(_activePressedStrokeVisual, 0.0f, Dur(ExitStrokeDurationMs));
 
                 if (_isPressed)
                 {
@@ -857,9 +875,10 @@ namespace FluentSensors.Features.TaskbarWidget
                     AnimateVisualOpacity(_activeHoverVisual, 0.0f, PressDurationMs);
                     AnimateVisualOpacity(_activePressedVisual, 0.0f, PressDurationMs);
                     AnimateVisualOpacity(_pressedVisual, 1.0f, PressDurationMs);
-                    // PressedBorder carries the whole pressed border (top highlight + sides); StrokeBorder on top
-                    // would composite its side color over PressedBorder and shift the pressed side target
-                    AnimateVisualOpacity(_strokeVisual, 0.0f, PressDurationMs);
+                    // the pressed border snaps (gated) while the fill above crossfades; StrokeBorder would shift the
+                    // pressed side target and is off in this state
+                    AnimateVisualOpacity(_pressedStrokeVisual, 1.0f, Dur(PressDurationMs));
+                    AnimateVisualOpacity(_strokeVisual, 0.0f, Dur(PressDurationMs));
                 }
                 else if (_isPointerOver)
                 {
@@ -867,7 +886,8 @@ namespace FluentSensors.Features.TaskbarWidget
                     AnimateVisualOpacity(_activeHoverVisual, 0.0f, HoverBackgroundDurationMs);
                     AnimateVisualOpacity(_activePressedVisual, 0.0f, HoverBackgroundDurationMs);
                     AnimateVisualOpacity(_pressedVisual, 0.0f, HoverBackgroundDurationMs);
-                    AnimateVisualOpacity(_strokeVisual, 1.0f, HoverStrokeDurationMs);
+                    AnimateVisualOpacity(_pressedStrokeVisual, 0.0f, Dur(PressDurationMs));
+                    AnimateVisualOpacity(_strokeVisual, 1.0f, Dur(HoverStrokeDurationMs));
                 }
                 else
                 {
@@ -875,13 +895,15 @@ namespace FluentSensors.Features.TaskbarWidget
                     AnimateVisualOpacity(_activeHoverVisual, 0.0f, ExitBackgroundDurationMs);
                     AnimateVisualOpacity(_activePressedVisual, 0.0f, ExitBackgroundDurationMs);
                     AnimateVisualOpacity(_pressedVisual, 0.0f, ExitBackgroundDurationMs);
-                    AnimateVisualOpacity(_strokeVisual, 0.0f, ExitStrokeDurationMs);
+                    AnimateVisualOpacity(_pressedStrokeVisual, 0.0f, Dur(PressDurationMs));
+                    AnimateVisualOpacity(_strokeVisual, 0.0f, Dur(ExitStrokeDurationMs));
                 }
             }
             else
             {
                 // === Flyout Open ===
-                AnimateVisualOpacity(_strokeVisual, 0.0f, ExitStrokeDurationMs);
+                AnimateVisualOpacity(_strokeVisual, 0.0f, Dur(ExitStrokeDurationMs));
+                AnimateVisualOpacity(_pressedStrokeVisual, 0.0f, Dur(PressDurationMs));
 
                 if (_isPressed)
                 {
@@ -890,8 +912,8 @@ namespace FluentSensors.Features.TaskbarWidget
                     AnimateVisualOpacity(_activePressedVisual, 1.0f, PressDurationMs);
                     AnimateVisualOpacity(_pressedVisual, 0.0f, PressDurationMs);
 
-                    AnimateVisualOpacity(_activeHoverStrokeVisual, 0.0f, PressDurationMs);
-                    AnimateVisualOpacity(_activePressedStrokeVisual, 1.0f, PressDurationMs);
+                    AnimateVisualOpacity(_activeHoverStrokeVisual, 0.0f, Dur(PressDurationMs));
+                    AnimateVisualOpacity(_activePressedStrokeVisual, 1.0f, Dur(PressDurationMs));
                 }
                 else if (_isPointerOver)
                 {
@@ -900,8 +922,8 @@ namespace FluentSensors.Features.TaskbarWidget
                     AnimateVisualOpacity(_activePressedVisual, 0.0f, HoverBackgroundDurationMs);
                     AnimateVisualOpacity(_pressedVisual, 0.0f, HoverBackgroundDurationMs);
 
-                    AnimateVisualOpacity(_activeHoverStrokeVisual, 1.0f, HoverStrokeDurationMs);
-                    AnimateVisualOpacity(_activePressedStrokeVisual, 0.0f, HoverStrokeDurationMs);
+                    AnimateVisualOpacity(_activeHoverStrokeVisual, 1.0f, Dur(HoverStrokeDurationMs));
+                    AnimateVisualOpacity(_activePressedStrokeVisual, 0.0f, Dur(HoverStrokeDurationMs));
                 }
                 else
                 {
@@ -911,9 +933,9 @@ namespace FluentSensors.Features.TaskbarWidget
                     AnimateVisualOpacity(_activePressedVisual, 0.0f, ExitBackgroundDurationMs);
                     AnimateVisualOpacity(_pressedVisual, 0.0f, ExitBackgroundDurationMs);
 
-                    AnimateVisualOpacity(_strokeVisual, 1.0f, ExitStrokeDurationMs);
-                    AnimateVisualOpacity(_activeHoverStrokeVisual, 0.0f, ExitStrokeDurationMs);
-                    AnimateVisualOpacity(_activePressedStrokeVisual, 0.0f, ExitStrokeDurationMs);
+                    AnimateVisualOpacity(_strokeVisual, 1.0f, Dur(ExitStrokeDurationMs));
+                    AnimateVisualOpacity(_activeHoverStrokeVisual, 0.0f, Dur(ExitStrokeDurationMs));
+                    AnimateVisualOpacity(_activePressedStrokeVisual, 0.0f, Dur(ExitStrokeDurationMs));
                 }
             }
 
@@ -1017,16 +1039,8 @@ namespace FluentSensors.Features.TaskbarWidget
             }
 
             _isPressed = true;
+            // UpdateVisualState drives the content press dim (to PressContentOpacity, matched across light and dark)
             UpdateVisualState();
-
-            // content press feedback: dims to PressContentOpacity while held, matched across light and dark
-            if (_contentVisual != null && _compositor != null)
-            {
-                var pressAnim = _compositor.CreateScalarKeyFrameAnimation();
-                pressAnim.InsertKeyFrame(1.0f, PressContentOpacity);
-                pressAnim.Duration = TimeSpan.FromMilliseconds(PressDurationMs);
-                _contentVisual.StartAnimation("Opacity", pressAnim);
-            }
         }
 
         private void TaskbarButton_PointerMoved(object sender, PointerRoutedEventArgs e)
@@ -1096,14 +1110,6 @@ namespace FluentSensors.Features.TaskbarWidget
             }
             _isPointerOver = isOverNow;
             UpdateVisualState();
-
-            if (_contentVisual != null && _compositor != null)
-            {
-                var relAnim = _compositor.CreateScalarKeyFrameAnimation();
-                relAnim.InsertKeyFrame(1.0f, 1.0f);
-                relAnim.Duration = TimeSpan.FromMilliseconds(PressDurationMs);
-                _contentVisual.StartAnimation("Opacity", relAnim);
-            }
         }
 
         private void TaskbarButton_PointerCaptureLost(object sender, PointerRoutedEventArgs e)

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -78,13 +78,14 @@ namespace FluentSensors.Features.TaskbarWidget
         private RectInt32 _currentScreenRect;
         private int _currentOffsetDip = AnchorOffsetDip;
 
-        // --- taskbar button animation timings (in milliseconds) ---
+        // --- taskbar button animation settings ---
         private const int HoverBackgroundDelayMs = 0; // delay before hover background starts (Standard Windows: 0ms)
         private const int HoverBackgroundDurationMs = 120; // duration of hover background fade-in (Standard Windows: 83ms [ControlFastAnimationDuration])
         private const int HoverStrokeDurationMs = 0; // duration of border stroke appearance on hover (Standard Windows: 0ms instant)
         private const int ExitBackgroundDurationMs = 180; // duration of background fade-out on exit (Standard Windows: 167ms [ControlNormalAnimationDuration])
         private const int ExitStrokeDurationMs = 40; // duration of border stroke fade-out on exit (Standard Windows: 40ms [ControlFasterAnimationDuration])
         private const int PressDurationMs = 50; // duration of press feedback animation (Standard Windows: 50ms)
+        private const float PressContentOpacity = 0.75f; // content dim while the button is held, same value in both themes
 
         // embedding can fail transiently, e.g. while the start menu is open or another app is mid-embed
         // retrying up to 5 times avoids reporting a false failure
@@ -918,9 +919,7 @@ namespace FluentSensors.Features.TaskbarWidget
             {
                 if (_isPressed)
                 {
-                    bool isLight = ((FrameworkElement)this.Content).ActualTheme == ElementTheme.Light;
-                    float targetOpacity = isLight ? 0.70f : 0.95f;
-                    AnimateVisualOpacity(_contentVisual, targetOpacity, PressDurationMs);
+                    AnimateVisualOpacity(_contentVisual, PressContentOpacity, PressDurationMs);
                 }
                 else
                 {
@@ -1018,13 +1017,11 @@ namespace FluentSensors.Features.TaskbarWidget
             _isPressed = true;
             UpdateVisualState();
 
-            // content press feedback: 70% opacity in Light mode, 95% opacity in Dark mode
+            // content press feedback: dims to PressContentOpacity while held, matched across light and dark
             if (_contentVisual != null && _compositor != null)
             {
-                bool isLight = ((FrameworkElement)this.Content).ActualTheme == ElementTheme.Light;
-                float targetOpacity = isLight ? 0.70f : 0.95f;
                 var pressAnim = _compositor.CreateScalarKeyFrameAnimation();
-                pressAnim.InsertKeyFrame(1.0f, targetOpacity);
+                pressAnim.InsertKeyFrame(1.0f, PressContentOpacity);
                 pressAnim.Duration = TimeSpan.FromMilliseconds(PressDurationMs);
                 _contentVisual.StartAnimation("Opacity", pressAnim);
             }

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -80,9 +80,9 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // --- taskbar button animation settings ---
         private const int HoverBackgroundDelayMs = 0; // delay before hover background starts (Standard Windows: 0ms)
-        private const int HoverBackgroundDurationMs = 120; // duration of hover background fade-in (Standard Windows: 83ms [ControlFastAnimationDuration])
+        private const int HoverBackgroundDurationMs = 83; // duration of hover background fade-in (Standard Windows: 83ms [ControlFastAnimationDuration])
         private const int HoverStrokeDurationMs = 0; // duration of border stroke appearance on hover (Standard Windows: 0ms instant)
-        private const int ExitBackgroundDurationMs = 180; // duration of background fade-out on exit (Standard Windows: 167ms [ControlNormalAnimationDuration])
+        private const int ExitBackgroundDurationMs = 167; // duration of background fade-out on exit (Standard Windows: 167ms [ControlNormalAnimationDuration])
         private const int ExitStrokeDurationMs = 40; // duration of border stroke fade-out on exit (Standard Windows: 40ms [ControlFasterAnimationDuration])
         private const int PressDurationMs = 50; // duration of press feedback animation (Standard Windows: 50ms)
         private const float PressContentOpacity = 0.75f; // content dim while the button is held, same value in both themes
@@ -857,7 +857,9 @@ namespace FluentSensors.Features.TaskbarWidget
                     AnimateVisualOpacity(_activeHoverVisual, 0.0f, PressDurationMs);
                     AnimateVisualOpacity(_activePressedVisual, 0.0f, PressDurationMs);
                     AnimateVisualOpacity(_pressedVisual, 1.0f, PressDurationMs);
-                    AnimateVisualOpacity(_strokeVisual, 1.0f, PressDurationMs);
+                    // PressedBorder carries the whole pressed border (top highlight + sides); StrokeBorder on top
+                    // would composite its side color over PressedBorder and shift the pressed side target
+                    AnimateVisualOpacity(_strokeVisual, 0.0f, PressDurationMs);
                 }
                 else if (_isPointerOver)
                 {


### PR DESCRIPTION
## What does this change

Reworks the taskbar widget button hover / pressed / active states.

- Fill and border colors calibrated for both Windows transparency modes
- Content press for light and dark

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English