### PR TITLE
Add CSV recording with a dedicated logger window

### DIFF
--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -25,18 +25,22 @@
                     <SolidColorBrush x:Key="TaskbarButtonPressedBackground" Color="#0BFFFFFF" />
 
                     <!--  2. Taskbar Button Borders (Dark Mode)  -->
-                    <!--  the border is never transparent: it carries the #1DFFFFFF top highlight and the same fill
-                          brush on the sides & bottom, so it always paints its 1px (no size shift between states) but
-                          reads as invisible where it should; #0FFFFFFF over #202020 == the hover fill
-                          top stop is #1D (not #16): the stroke composites over the bare bar now that the fill is
-                          inset, so it needs the higher alpha to land ~#404040 and match the native taskbar highlight  -->
+                    <!--
+                        the border is never transparent: it carries the #1DFFFFFF top highlight and the same fill
+                        brush on the sides & bottom, so it always paints its 1px (no size shift between states) but
+                        reads as invisible where it should; #0FFFFFFF over #202020 == the hover fill
+                        top stop is #1D (not #16): the stroke composites over the bare bar now that the fill is
+                        inset, so it needs the higher alpha to land ~#404040 and match the native taskbar highlight
+                    -->
                     <LinearGradientBrush x:Key="TaskbarButtonBorderBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientStop Offset="0.0" Color="#1DFFFFFF" />
                         <GradientStop Offset="0.10" Color="#0FFFFFFF" />
                         <GradientStop Offset="1.0" Color="#0FFFFFFF" />
                     </LinearGradientBrush>
-                    <!--  Normal Pressed Border: sole source of the pressed border (StrokeBorder is off in this state),
-                          so the top stop is self-sufficient at #1FFFFFFF -> #3B3B3B; sides & bottom #10FFFFFF -> #2E2E2E  -->
+                    <!--
+                        Normal Pressed Border: sole source of the pressed border (StrokeBorder is off in this state),
+                        so the top stop is self-sufficient at #1FFFFFFF -> #3B3B3B; sides & bottom #10FFFFFF -> #2E2E2E
+                    -->
                     <LinearGradientBrush x:Key="TaskbarButtonPressedBorderBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientStop Offset="0.0" Color="#1FFFFFFF" />
                         <GradientStop Offset="0.12" Color="#10FFFFFF" />
@@ -46,8 +50,10 @@
                     <!--  3. Active Flyout State (When Flyout is currently OPEN)  -->
                     <!--  Active Hover -> Target #323232 (50): Alpha 21 (0x15) -> #15FFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonActiveHoverBackground" Color="#15FFFFFF" />
-                    <!--  Active Hover Border: same #1DFFFFFF top highlight as normal hover (~#404040, native match),
-                          active-hover fill brush on sides & bottom so the 1px there reads as invisible  -->
+                    <!--
+                        Active Hover Border: same #1DFFFFFF top highlight as normal hover (~#404040, native match),
+                        active-hover fill brush on sides & bottom so the 1px there reads as invisible
+                    -->
                     <LinearGradientBrush x:Key="TaskbarButtonActiveHoverBorderBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientStop Offset="0.0" Color="#1DFFFFFF" />
                         <GradientStop Offset="0.10" Color="#15FFFFFF" />
@@ -103,15 +109,19 @@
                     <SolidColorBrush x:Key="TaskbarButtonPressedBackground" Color="#55FFFFFF" />
 
                     <!--  2. Taskbar Button Border (Normal Hover & Pressed)  -->
-                    <!--  alpha black so it tracks the bar; calibrated against the transparency-on light taskbar (~#F0F0F0)
-                          to land top & sides #E7E7E7, bottom #DDDDDD there; over the #EDEDED solid bar it reads ~2 levels darker  -->
+                    <!--
+                        alpha black so it tracks the bar; calibrated against the transparency-on light taskbar (~#F0F0F0)
+                        to land top & sides #E7E7E7, bottom #DDDDDD there; over the #EDEDED solid bar it reads ~2 levels darker
+                    -->
                     <LinearGradientBrush x:Key="TaskbarButtonBorderBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientStop Offset="0.0" Color="#0A000000" />
                         <GradientStop Offset="0.75" Color="#0A000000" />
                         <GradientStop Offset="1.0" Color="#14000000" />
                     </LinearGradientBrush>
-                    <!--  Normal Pressed Border: sole source of the pressed border now (StrokeBorder is off in this state),
-                          same alpha-black values as TaskbarButtonBorderBrush -> top & sides #E7E7E7, bottom #DDDDDD  -->
+                    <!--
+                        Normal Pressed Border: sole source of the pressed border now (StrokeBorder is off in this state),
+                        same alpha-black values as TaskbarButtonBorderBrush -> top & sides #E7E7E7, bottom #DDDDDD
+                    -->
                     <LinearGradientBrush x:Key="TaskbarButtonPressedBorderBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientStop Offset="0.0" Color="#0A000000" />
                         <GradientStop Offset="0.75" Color="#0A000000" />
@@ -121,8 +131,10 @@
                     <!--  3. Active Flyout State (When Flyout is currently OPEN)  -->
                     <!--  Active Hover -> Target #FAFAFA (250): Alpha 184 (0xB8) -> #B8FFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonActiveHoverBackground" Color="#B8FFFFFF" />
-                    <!--  Active Hover Border: alpha black, calibrated against the transparency-on light taskbar (~#F0F0F0)
-                          to land top & sides #E5E5E5, bottom #D4D4D4 there  -->
+                    <!--
+                        Active Hover Border: alpha black, calibrated against the transparency-on light taskbar (~#F0F0F0)
+                        to land top & sides #E5E5E5, bottom #D4D4D4 there
+                    -->
                     <LinearGradientBrush x:Key="TaskbarButtonActiveHoverBorderBrush" StartPoint="0,0" EndPoint="0,1">
                         <GradientStop Offset="0.0" Color="#0C000000" />
                         <GradientStop Offset="0.75" Color="#0C000000" />
@@ -131,8 +143,10 @@
 
                     <!--  Active Pressed -> Target #F3F3F3 (243): Alpha 85 (0x55) -> #55FFFFFF  -->
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBackground" Color="#55FFFFFF" />
-                    <!--  Active Pressed Border: alpha black over the bare bar (the fill layer is inset like the others now),
-                          calibrated against the transparency-on light taskbar (~#F0F0F0) to land #E7E7E7 on all 4 sides  -->
+                    <!--
+                        Active Pressed Border: alpha black over the bare bar (the fill layer is inset like the others now),
+                        calibrated against the transparency-on light taskbar (~#F0F0F0) to land #E7E7E7 on all 4 sides
+                    -->
                     <SolidColorBrush x:Key="TaskbarButtonActivePressedBorderBrush" Color="#0A000000" />
 
                     <!--  4. Flyout Window Styling (Light Mode)  -->
@@ -163,6 +177,97 @@
                     <SolidColorBrush x:Key="FlyoutBottomBarSeparatorOnGlassBrush" Color="#13000000" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
+
+
+            <!--  === custom subtle button ===  -->
+            <!--
+                the platform SubtleButtonStyle fades its fill in over 83 ms but swaps the border brush in the
+                frame the state changes, and both resolve to the same brush; a hover therefore starts as a 1px
+                outline in the final color around a still empty button
+                every state brush below is the one the platform style uses, the border just stays transparent in
+                all of them, and the fill is sized to the outer border edge so it still covers the full box
+            -->
+            <Style x:Key="SubtleBarButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="{ThemeResource SubtleButtonBackground}" />
+                <Setter Property="BackgroundSizing" Value="OuterBorderEdge" />
+                <Setter Property="Foreground" Value="{ThemeResource SubtleButtonForeground}" />
+                <Setter Property="BorderBrush" Value="{ThemeResource SubtleButtonBorderBrush}" />
+                <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
+                <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                <Setter Property="FontWeight" Value="Normal" />
+                <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                <Setter Property="FocusVisualMargin" Value="-3" />
+                <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <ContentPresenter
+                                x:Name="ContentPresenter"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                AutomationProperties.AccessibilityView="Raw"
+                                Background="{TemplateBinding Background}"
+                                BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                ContentTransitions="{TemplateBinding ContentTransitions}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                                <!--  the value of ControlFasterAnimationDuration  -->
+                                <!--  (spelled out because BrushTransition.Duration is a TimeSpan and the platform keys are strings; the platform button hardcodes it the same way)  -->
+                                <ContentPresenter.BackgroundTransition>
+                                    <BrushTransition Duration="0:0:0.083" />
+                                </ContentPresenter.BackgroundTransition>
+
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal" />
+
+                                        <VisualState x:Name="PointerOver">
+                                            <Storyboard>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonBackgroundPointerOver}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonForegroundPointerOver}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="Pressed">
+                                            <Storyboard>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonBackgroundPressed}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonForegroundPressed}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="Disabled">
+                                            <Storyboard>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonBackgroundDisabled}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleButtonForegroundDisabled}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+                            </ContentPresenter>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/FluentSensors/Common/Csv/CsvNumberFormat.cs
+++ b/FluentSensors/Common/Csv/CsvNumberFormat.cs
@@ -1,0 +1,18 @@
+namespace FluentSensors.Common.Csv
+{
+    // how a recording writes its separators and decimals
+    //
+    // the distinction is not cosmetic: a german Excel or LibreOffice reads the point in "2515.862" as a thousands
+    // separator and opens the value as 2515862, because a three digit group is exactly what a thousands group looks
+    // like; only values with one or two decimals survive that, which is why the damage looks random
+    public enum CsvNumberFormat
+    {
+        // separators taken from the machines own regional settings, so the file opens correctly by double click
+        // in the spreadsheet app that is installed on it
+        Local,
+
+        // RFC 4180: comma separated, point decimal, no matter where the file is written
+        // what scripts, pandas and every non-localized reader expect
+        Invariant
+    }
+}

--- a/FluentSensors/Common/Csv/CsvPauseSeam.cs
+++ b/FluentSensors/Common/Csv/CsvPauseSeam.cs
@@ -1,0 +1,17 @@
+namespace FluentSensors.Common.Csv
+{
+    // what a resumed recording writes at the seam where the pause was
+    //
+    // the distinction only matters to whatever reads the file afterwards: a chart drawn straight through the seam
+    // claims a measurement that was never taken, while a broken line says the truth
+    public enum CsvPauseSeam
+    {
+        // one row of empty fields, so a spreadsheet breaks its line there instead of interpolating across the pause
+        // (deliberately empty fields and not an empty line: the column count has to survive, and a truly blank line
+        // ends the data range on import)
+        Gap,
+
+        // the next measurement follows the last one directly; the pause is only visible in the timestamps
+        Seamless
+    }
+}

--- a/FluentSensors/Common/Csv/CsvRowFormat.cs
+++ b/FluentSensors/Common/Csv/CsvRowFormat.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+
+using FluentSensors.Persistence.Services;
+
+
+namespace FluentSensors.Common.Csv
+{
+    // everything a recorded row needs to turn a double into text, resolved once from the settings
+    //
+    // bundled into one object because a recording has to snapshot all of it together: switching any single piece
+    // midway through an open file would leave the rows before and after it formatted differently, and nothing
+    // reading the file would notice
+    public sealed class CsvRowFormat
+    {
+        private CsvRowFormat(string separator, CultureInfo valueCulture, string valueFormat, bool includeUnits)
+        {
+            Separator = separator;
+            ValueCulture = valueCulture;
+            ValueFormat = valueFormat;
+            IncludeUnits = includeUnits;
+        }
+
+
+        // === resolved pieces ===
+
+        public string Separator { get; }
+        public CultureInfo ValueCulture { get; }
+
+        // "0", "0.0", "0.00" or "0.000"
+        // fixed rather than trimming ("0.###"), so every cell of a column is the same width and the settings page
+        // can show one sample that stands for all of them
+        public string ValueFormat { get; }
+
+        public bool IncludeUnits { get; }
+
+
+        // === resolution ===
+
+        // resolves the configured format into the pieces a row actually needs
+        // Local reads the machines own regional settings rather than hardcoding german, so the file matches
+        // whatever spreadsheet app is installed on the system that wrote it
+        public static CsvRowFormat Resolve()
+        {
+            var settings = SettingsService.Instance;
+
+            string valueFormat = BuildValueFormat(settings.CsvDecimalPlaces);
+            bool includeUnits = settings.CsvIncludeUnits;
+
+            if (settings.CsvNumberFormat == CsvNumberFormat.Invariant)
+            {
+                return new CsvRowFormat(",", CultureInfo.InvariantCulture, valueFormat, includeUnits);
+            }
+
+            var culture = CultureInfo.CurrentCulture;
+            string separator = culture.TextInfo.ListSeparator;
+
+            // a locale whose list separator is also its decimal separator would write rows nothing can read back;
+            // the semicolon is what every spreadsheet falls back to in that case
+            if (separator == culture.NumberFormat.NumberDecimalSeparator) separator = ";";
+
+            return new CsvRowFormat(separator, culture, valueFormat, includeUnits);
+        }
+
+        private static string BuildValueFormat(int decimalPlaces)
+        {
+            if (decimalPlaces <= 0) return "0";
+
+            return "0." + new string('0', decimalPlaces);
+        }
+
+
+        // === formatting ===
+
+        // one measurement as it lands in the file
+        // the unit is appended only when it was asked for; note that this turns the cell into text, so a file
+        // written that way is for reading and no longer for charting
+        public string FormatValue(double value, string unit)
+        {
+            string text = value.ToString(ValueFormat, ValueCulture);
+
+            if (!IncludeUnits || string.IsNullOrEmpty(unit)) return text;
+
+            return text + " " + unit;
+        }
+    }
+}

--- a/FluentSensors/Features/CsvLogging/CsvLoggerViewModel.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerViewModel.cs
@@ -1,0 +1,296 @@
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+using FluentSensors.Persistence.Services;
+
+
+namespace FluentSensors.Features.CsvLogging
+{
+    // readout for CsvLoggerWindow: what the two buttons are allowed to do plus the three live counters
+    //
+    // holds no recording state of its own, everything is read back from CsvLoggingService, so a window that was
+    // hidden and later reopened (or fully rebuilt) picks the running recording up exactly where it stands
+    public class CsvLoggerViewModel : INotifyPropertyChanged
+    {
+        // === fields ===
+
+        private readonly DispatcherQueue _dispatcherQueue;
+        private DispatcherQueueTimer _tickTimer;
+
+        // how often the elapsed clock and the row counter are re-read while recording; unrelated to the sensor poll
+        // interval, this only drives text
+        private const int TickIntervalMs = 500;
+
+        // whether the window is actually on screen; a hidden or minimized logger stops ticking, the recording in
+        // CsvLoggingService keeps running either way
+        private bool _isReadoutActive = true;
+
+        // one-off message set when the sensors page pushes a selection at a running recording; cleared again by the
+        // next real state change
+        private string _transientHint;
+
+
+        // === constructor ===
+
+        public CsvLoggerViewModel()
+        {
+            _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+
+            CsvLoggingService.Instance.StateChanged += OnLoggingStateChanged;
+
+            RefreshAll();
+            UpdateTickTimer();
+        }
+
+
+        // === bindable properties ===
+
+        private bool _isRunning;
+        public bool IsRunning
+        {
+            get => _isRunning;
+            private set
+            {
+                if (_isRunning == value) return;
+                _isRunning = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(CanStart));
+                OnPropertyChanged(nameof(CanStop));
+            }
+        }
+
+        public bool CanStart => !CsvLoggingService.Instance.IsRunning && CsvLoggingService.Instance.SensorCount > 0;
+        public bool CanStop => CsvLoggingService.Instance.IsRunning;
+
+        // start and stop share the same slot in the main bar, only one of them is ever up
+        public Visibility StartButtonVisibility => CsvLoggingService.Instance.IsRunning ? Visibility.Collapsed : Visibility.Visible;
+        public Visibility StopButtonVisibility => CsvLoggingService.Instance.IsRunning ? Visibility.Visible : Visibility.Collapsed;
+
+        private string _logFolderText = "";
+        public string LogFolderText
+        {
+            get => _logFolderText;
+            private set
+            {
+                if (_logFolderText == value) return;
+                _logFolderText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string _elapsedText = "00:00:00";
+        public string ElapsedText
+        {
+            get => _elapsedText;
+            private set
+            {
+                if (_elapsedText == value) return;
+                _elapsedText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string _sensorCountText = "0";
+        public string SensorCountText
+        {
+            get => _sensorCountText;
+            private set
+            {
+                if (_sensorCountText == value) return;
+                _sensorCountText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string _rowCountText = "0";
+        public string RowCountText
+        {
+            get => _rowCountText;
+            private set
+            {
+                if (_rowCountText == value) return;
+                _rowCountText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string _statusText = "";
+        public string StatusText
+        {
+            get => _statusText;
+            private set
+            {
+                if (_statusText == value) return;
+                _statusText = value;
+                OnPropertyChanged();
+            }
+        }
+
+
+        // === public methods ===
+
+        public void Start()
+        {
+            CsvLoggingService.Instance.Start();
+        }
+
+        public void Stop()
+        {
+            CsvLoggingService.Instance.Stop();
+        }
+
+        // takes over a folder the user just picked and drops any earlier start failure with it
+        public void SetLogFolder(string folder)
+        {
+            SettingsService.Instance.CsvLogFolder = folder;
+            CsvLoggingService.Instance.ClearLastError();
+
+            LogFolderText = CsvLoggingService.Instance.ResolvedLogFolder;
+        }
+
+        // shown when the sensors page pushes a new selection while a recording runs; the columns are already fixed
+        // in the open file, so the selection was not taken over and the window has to say so
+        public void ShowSelectionLockedHint()
+        {
+            _transientHint = "stop the recording first to change the sensor selection";
+            StatusText = BuildStatusText();
+        }
+
+        // pauses the readout while the window is hidden or minimized, so a logger nobody is looking at costs
+        // nothing; the recording itself is untouched, only the text stops updating
+        public void SetReadoutActive(bool active)
+        {
+            if (_isReadoutActive == active) return;
+            _isReadoutActive = active;
+
+            UpdateTickTimer();
+
+            if (active)
+            {
+                RefreshAll();
+            }
+        }
+
+        public void Cleanup()
+        {
+            CsvLoggingService.Instance.StateChanged -= OnLoggingStateChanged;
+
+            _isReadoutActive = false;
+            UpdateTickTimer();
+        }
+
+
+        // === event handlers ===
+
+        private void OnLoggingStateChanged()
+        {
+            _transientHint = null;
+
+            RefreshAll();
+            UpdateTickTimer();
+        }
+
+        private void OnTick(DispatcherQueueTimer sender, object args)
+        {
+            RefreshCounters();
+        }
+
+
+        // === private helpers ===
+
+        // the timer only exists while a visible window is showing a running recording
+        private void UpdateTickTimer()
+        {
+            bool shouldTick = _isReadoutActive && CsvLoggingService.Instance.IsRunning;
+
+            if (shouldTick)
+            {
+                if (_tickTimer != null) return;
+
+                _tickTimer = _dispatcherQueue.CreateTimer();
+                _tickTimer.Interval = TimeSpan.FromMilliseconds(TickIntervalMs);
+                _tickTimer.IsRepeating = true;
+                _tickTimer.Tick += OnTick;
+                _tickTimer.Start();
+            }
+            else
+            {
+                if (_tickTimer == null) return;
+
+                _tickTimer.Tick -= OnTick;
+                _tickTimer.Stop();
+                _tickTimer = null;
+            }
+        }
+
+        private void RefreshAll()
+        {
+            var service = CsvLoggingService.Instance;
+
+            IsRunning = service.IsRunning;
+            OnPropertyChanged(nameof(CanStart));
+            OnPropertyChanged(nameof(CanStop));
+            OnPropertyChanged(nameof(StartButtonVisibility));
+            OnPropertyChanged(nameof(StopButtonVisibility));
+
+            SensorCountText = service.SensorCount.ToString();
+            LogFolderText = service.ResolvedLogFolder;
+            RefreshCounters();
+        }
+
+        private void RefreshCounters()
+        {
+            var service = CsvLoggingService.Instance;
+
+            ElapsedText = FormatElapsed(service.Elapsed);
+            RowCountText = service.RowCount.ToString("N0");
+            StatusText = BuildStatusText();
+        }
+
+        // hours are counted as a running total rather than through a TimeSpan format string; the "hh" specifier wraps
+        // at 24 and would silently show a two day recording as a two hour one
+        private static string FormatElapsed(TimeSpan elapsed)
+        {
+            return $"{(int)elapsed.TotalHours:00}:{elapsed.Minutes:00}:{elapsed.Seconds:00}";
+        }
+
+        private string BuildStatusText()
+        {
+            if (_transientHint != null) return _transientHint;
+
+            var service = CsvLoggingService.Instance;
+
+            if (service.LastError != null) return service.LastError;
+
+            if (service.IsRunning)
+            {
+                return $"recording to {Path.GetFileName(service.CurrentFilePath)}";
+            }
+
+            if (service.SensorCount == 0)
+            {
+                return "no sensors picked yet, select some in the sensor list";
+            }
+
+            if (service.CurrentFilePath != null)
+            {
+                return $"saved {service.RowCount:N0} rows to {Path.GetFileName(service.CurrentFilePath)}";
+            }
+
+            return "ready to record";
+        }
+
+
+        // === INotifyPropertyChanged implementation ===
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/FluentSensors/Features/CsvLogging/CsvLoggerViewModel.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerViewModel.cs
@@ -62,6 +62,21 @@ namespace FluentSensors.Features.CsvLogging
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(CanStart));
                 OnPropertyChanged(nameof(CanStop));
+                OnPropertyChanged(nameof(PauseButtonVisibility));
+            }
+        }
+
+        private bool _isPaused;
+        public bool IsPaused
+        {
+            get => _isPaused;
+            private set
+            {
+                if (_isPaused == value) return;
+                _isPaused = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(PauseGlyph));
+                OnPropertyChanged(nameof(PauseTooltip));
             }
         }
 
@@ -71,6 +86,15 @@ namespace FluentSensors.Features.CsvLogging
         // start and stop share the same slot in the main bar, only one of them is ever up
         public Visibility StartButtonVisibility => CsvLoggingService.Instance.IsRunning ? Visibility.Collapsed : Visibility.Visible;
         public Visibility StopButtonVisibility => CsvLoggingService.Instance.IsRunning ? Visibility.Visible : Visibility.Collapsed;
+
+        // the pause button only exists while there is a recording to hold; unlike start and stop it is a single
+        // button that swaps its glyph, the way the details chevron next to it does
+        public Visibility PauseButtonVisibility => CsvLoggingService.Instance.IsRunning ? Visibility.Visible : Visibility.Collapsed;
+
+        // segoe fluent icons Pause and Play, escaped rather than pasted so this file stays plain ascii like the
+        // rest of the sources
+        public string PauseGlyph => IsPaused ? "\uE768" : "\uE769";
+        public string PauseTooltip => IsPaused ? "Resume" : "Pause";
 
         private string _logFolderText = "";
         public string LogFolderText
@@ -84,14 +108,42 @@ namespace FluentSensors.Features.CsvLogging
             }
         }
 
-        private string _elapsedText = "00:00:00";
-        public string ElapsedText
+        // the stretch covered by rows, which is what the main bar shows next to the row counter
+        private string _recordedElapsedText = "00:00:00";
+        public string RecordedElapsedText
         {
-            get => _elapsedText;
+            get => _recordedElapsedText;
             private set
             {
-                if (_elapsedText == value) return;
-                _elapsedText = value;
+                if (_recordedElapsedText == value) return;
+                _recordedElapsedText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        // wall clock since start, pauses included; only shown in the details region, and the value that matches
+        // the elapsed column in the file
+        private string _totalElapsedText = "00:00:00";
+        public string TotalElapsedText
+        {
+            get => _totalElapsedText;
+            private set
+            {
+                if (_totalElapsedText == value) return;
+                _totalElapsedText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        // the reason the two durations above differ
+        private string _pauseCountText = "0";
+        public string PauseCountText
+        {
+            get => _pauseCountText;
+            private set
+            {
+                if (_pauseCountText == value) return;
+                _pauseCountText = value;
                 OnPropertyChanged();
             }
         }
@@ -121,7 +173,7 @@ namespace FluentSensors.Features.CsvLogging
         }
 
         // elapsed clock and row counter in one line, for the main bar where a single value has to carry both
-        private string _elapsedRowsText = "00:00:00|0";
+        private string _elapsedRowsText = "00:00:00 | 0";
         public string ElapsedRowsText
         {
             get => _elapsedRowsText;
@@ -168,6 +220,20 @@ namespace FluentSensors.Features.CsvLogging
         public void Stop()
         {
             CsvLoggingService.Instance.Stop();
+        }
+
+        public void TogglePause()
+        {
+            var service = CsvLoggingService.Instance;
+
+            if (service.IsPaused)
+            {
+                service.Resume();
+            }
+            else
+            {
+                service.Pause();
+            }
         }
 
         // takes over a folder the user just picked and drops any earlier start failure with it
@@ -266,10 +332,12 @@ namespace FluentSensors.Features.CsvLogging
             var service = CsvLoggingService.Instance;
 
             IsRunning = service.IsRunning;
+            IsPaused = service.IsPaused;
             OnPropertyChanged(nameof(CanStart));
             OnPropertyChanged(nameof(CanStop));
             OnPropertyChanged(nameof(StartButtonVisibility));
             OnPropertyChanged(nameof(StopButtonVisibility));
+            OnPropertyChanged(nameof(PauseButtonVisibility));
 
             SensorCountText = service.SensorCount.ToString();
             LogFolderText = service.ResolvedLogFolder;
@@ -281,9 +349,11 @@ namespace FluentSensors.Features.CsvLogging
         {
             var service = CsvLoggingService.Instance;
 
-            ElapsedText = FormatElapsed(service.Elapsed);
+            RecordedElapsedText = FormatElapsed(service.RecordedElapsed);
+            TotalElapsedText = FormatElapsed(service.Elapsed);
+            PauseCountText = service.PauseCount.ToString();
             RowCountText = service.RowCount.ToString("N0");
-            ElapsedRowsText = $"{ElapsedText} | {RowCountText}";
+            ElapsedRowsText = $"{RecordedElapsedText} | {RowCountText}";
             StatusText = BuildStatusText();
         }
 
@@ -307,6 +377,11 @@ namespace FluentSensors.Features.CsvLogging
             var service = CsvLoggingService.Instance;
 
             if (service.LastError != null) return service.LastError;
+
+            if (service.IsPaused)
+            {
+                return $"paused at {service.RowCount:N0} rows";
+            }
 
             if (service.IsRunning)
             {

--- a/FluentSensors/Features/CsvLogging/CsvLoggerViewModel.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerViewModel.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.CompilerServices;
 
+using FluentSensors.Core;
 using FluentSensors.Persistence.Services;
 
 
@@ -41,6 +42,7 @@ namespace FluentSensors.Features.CsvLogging
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
             CsvLoggingService.Instance.StateChanged += OnLoggingStateChanged;
+            HardwareMonitorService.Instance.UpdateIntervalChanged += OnUpdateIntervalChanged;
 
             RefreshAll();
             UpdateTickTimer();
@@ -118,6 +120,31 @@ namespace FluentSensors.Features.CsvLogging
             }
         }
 
+        // elapsed clock and row counter in one line, for the main bar where a single value has to carry both
+        private string _elapsedRowsText = "00:00:00|0";
+        public string ElapsedRowsText
+        {
+            get => _elapsedRowsText;
+            private set
+            {
+                if (_elapsedRowsText == value) return;
+                _elapsedRowsText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string _pollingText = "0 ms";
+        public string PollingText
+        {
+            get => _pollingText;
+            private set
+            {
+                if (_pollingText == value) return;
+                _pollingText = value;
+                OnPropertyChanged();
+            }
+        }
+
         private string _statusText = "";
         public string StatusText
         {
@@ -178,6 +205,7 @@ namespace FluentSensors.Features.CsvLogging
         public void Cleanup()
         {
             CsvLoggingService.Instance.StateChanged -= OnLoggingStateChanged;
+            HardwareMonitorService.Instance.UpdateIntervalChanged -= OnUpdateIntervalChanged;
 
             _isReadoutActive = false;
             UpdateTickTimer();
@@ -192,6 +220,12 @@ namespace FluentSensors.Features.CsvLogging
 
             RefreshAll();
             UpdateTickTimer();
+        }
+
+        // the polling rate is a setting, so it is picked up when it changes instead of polled on the tick below
+        private void OnUpdateIntervalChanged(int newIntervalMs)
+        {
+            PollingText = FormatPolling();
         }
 
         private void OnTick(DispatcherQueueTimer sender, object args)
@@ -239,6 +273,7 @@ namespace FluentSensors.Features.CsvLogging
 
             SensorCountText = service.SensorCount.ToString();
             LogFolderText = service.ResolvedLogFolder;
+            PollingText = FormatPolling();
             RefreshCounters();
         }
 
@@ -248,7 +283,14 @@ namespace FluentSensors.Features.CsvLogging
 
             ElapsedText = FormatElapsed(service.Elapsed);
             RowCountText = service.RowCount.ToString("N0");
+            ElapsedRowsText = $"{ElapsedText} | {RowCountText}";
             StatusText = BuildStatusText();
+        }
+
+        // the rate the user set, not the measured one; a number that only moves when they move it
+        private static string FormatPolling()
+        {
+            return $"{HardwareMonitorService.Instance.UpdateIntervalMs} ms";
         }
 
         // hours are counted as a running total rather than through a TimeSpan format string; the "hh" specifier wraps

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
@@ -9,7 +9,7 @@
     Title="Fluent Sensors"
     mc:Ignorable="d">
 
-    <Grid x:Name="RootGrid" Background="Transparent">
+    <Grid x:Name="RootGrid" Background="{ThemeResource LayerFillColorDefaultBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -59,7 +59,7 @@
         <StackPanel
             x:Name="UpperRegion"
             Grid.Row="1"
-            Margin="4,0,4,4"
+            Margin="4,0,4,5"
             Spacing="4">
 
             <!--  main bar: start and stop share one slot, only one of them is ever up  -->
@@ -74,18 +74,25 @@
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Center"
                     Click="StartLogging_Click"
-                    Content="Start logging"
                     IsEnabled="{x:Bind ViewModel.CanStart, Mode=OneWay}"
-                    Style="{ThemeResource AccentButtonStyle}"
-                    Visibility="{x:Bind ViewModel.StartButtonVisibility, Mode=OneWay}" />
+                    Visibility="{x:Bind ViewModel.StartButtonVisibility, Mode=OneWay}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE768;" />
+                        <TextBlock Text="Start logging" />
+                    </StackPanel>
+                </Button>
 
                 <Button
                     Grid.Column="0"
                     HorizontalAlignment="Stretch"
                     HorizontalContentAlignment="Center"
                     Click="StopLogging_Click"
-                    Content="Stop logging"
-                    Visibility="{x:Bind ViewModel.StopButtonVisibility, Mode=OneWay}" />
+                    Visibility="{x:Bind ViewModel.StopButtonVisibility, Mode=OneWay}">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="14" Glyph="&#xE71A;" />
+                        <TextBlock Text="Stop logging" />
+                    </StackPanel>
+                </Button>
 
                 <Button
                     x:Name="ToggleDetailsButton"
@@ -110,6 +117,7 @@
         <!--  divider  -->
         <!--  (deliberately without a margin so it touches both window edges)  -->
         <Border
+            x:Name="Divider"
             Grid.Row="2"
             Height="1"
             HorizontalAlignment="Stretch"
@@ -118,80 +126,94 @@
 
         <!--  lower region  -->
         <!--  the live readout and the save location, collapsed together by the chevron above  -->
-        <StackPanel
+        <!--
+            (the layer brush sits on the row itself instead of on the padded stack inside it, so it fills
+            everything below the divider edge to edge)
+        -->
+        <Grid
             x:Name="LowerRegion"
             Grid.Row="3"
-            Margin="4,10,4,12"
-            Background="{ThemeResource LayerFillColorDefaultBrush}"
-            Spacing="12">
+            Background="{ThemeResource LayerFillColorDefaultBrush}">
 
-            <!--  (same label above value shape the hardware view info panels use)  -->
-            <controls:WrapPanel
-                Padding="4"
-                HorizontalSpacing="12"
-                VerticalSpacing="12">
-                <StackPanel Width="Auto" Spacing="2">
-                    <TextBlock
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Style="{ThemeResource CaptionTextBlockStyle}"
-                        Text="Pinned sensors"
-                        TextWrapping="Wrap" />
-                    <TextBlock
-                        Style="{ThemeResource BodyTextBlockStyle}"
-                        Text="{x:Bind ViewModel.SensorCountText, Mode=OneWay}"
-                        TextWrapping="Wrap" />
-                </StackPanel>
+            <StackPanel Margin="4,4,4,5" Spacing="8">
 
-                <StackPanel Width="Auto" Spacing="2">
-                    <TextBlock
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Style="{ThemeResource CaptionTextBlockStyle}"
-                        Text="Running for"
-                        TextWrapping="Wrap" />
-                    <TextBlock
-                        Style="{ThemeResource BodyTextBlockStyle}"
-                        Text="{x:Bind ViewModel.ElapsedText, Mode=OneWay}"
-                        TextWrapping="Wrap" />
-                </StackPanel>
+                <!--  (same label above value shape the hardware view info panels use)  -->
+                <controls:WrapPanel
+                    Padding="6,4,6,4"
+                    HorizontalSpacing="14"
+                    VerticalSpacing="8">
 
-                <StackPanel Width="Auto" Spacing="2">
-                    <TextBlock
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Style="{ThemeResource CaptionTextBlockStyle}"
-                        Text="Recorded rows"
-                        TextWrapping="Wrap" />
-                    <TextBlock
-                        Style="{ThemeResource BodyTextBlockStyle}"
-                        Text="{x:Bind ViewModel.RowCountText, Mode=OneWay}"
-                        TextWrapping="Wrap" />
-                </StackPanel>
-            </controls:WrapPanel>
+                    <!--  running time  -->
+                    <StackPanel Width="Auto" Spacing="2">
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource CaptionTextBlockStyle}"
+                            Text="Running for"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            Text="{x:Bind ViewModel.ElapsedText, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
 
-            <!--  save location  -->
-            <!--  (picked up front so start never has to ask)  -->
-            <Button
-                HorizontalAlignment="Stretch"
-                HorizontalContentAlignment="Left"
-                Click="PickLogFolder_Click"
-                ToolTipService.ToolTip="{x:Bind ViewModel.LogFolderText, Mode=OneWay}">
-                <Grid ColumnSpacing="8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="*" />
-                    </Grid.ColumnDefinitions>
+                    <!--  number of recorded rows  -->
+                    <StackPanel Width="Auto" Spacing="2">
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource CaptionTextBlockStyle}"
+                            Text="Recorded rows"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            Text="{x:Bind ViewModel.RowCountText, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
 
-                    <FontIcon
-                        Grid.Column="0"
-                        FontSize="14"
-                        Glyph="&#xE8B7;" />
-                    <TextBlock
-                        Grid.Column="1"
-                        VerticalAlignment="Center"
-                        Style="{ThemeResource CaptionTextBlockStyle}"
-                        Text="{x:Bind ViewModel.LogFolderText, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis" />
-                </Grid>
-            </Button>
-        </StackPanel>
+                    <!--  number of pinned sensors  -->
+                    <StackPanel Width="Auto" Spacing="2">
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource CaptionTextBlockStyle}"
+                            Text="Pinned sensors"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            Text="{x:Bind ViewModel.SensorCountText, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </controls:WrapPanel>
+
+                <!--  save location  -->
+                <!--  (picked up front so start never has to ask)  -->
+                <!--
+                    (MinHeight is the height a default Button ends up at in the main bar, spelled out here so
+                    both bars stay the same even though this one carries smaller text)
+                -->
+                <Button
+                    MinHeight="32"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Left"
+                    Click="PickLogFolder_Click"
+                    ToolTipService.ToolTip="{x:Bind ViewModel.LogFolderText, Mode=OneWay}">
+                    <Grid ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <FontIcon
+                            Grid.Column="0"
+                            FontSize="14"
+                            Glyph="&#xE8B7;" />
+                        <TextBlock
+                            Grid.Column="1"
+                            VerticalAlignment="Center"
+                            Style="{ThemeResource CaptionTextBlockStyle}"
+                            Text="{x:Bind ViewModel.LogFolderText, Mode=OneWay}"
+                            TextTrimming="CharacterEllipsis" />
+                    </Grid>
+                </Button>
+            </StackPanel>
+        </Grid>
     </Grid>
 </Window>

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
@@ -45,11 +45,11 @@
                         Glyph="&#xE944;" />
                 </Button>
 
-                <TextBlock
+                <!--<TextBlock
                     Margin="4,0,0,0"
                     VerticalAlignment="Center"
                     Style="{ThemeResource CaptionTextBlockStyle}"
-                    Text="CSV Logging" />
+                    Text="CSV Logging" />-->
             </StackPanel>
         </Grid>
 

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
@@ -23,19 +23,19 @@
         <Grid
             x:Name="CustomTitleBar"
             Grid.Row="0"
-            Height="32"
+            Height="28"
             Background="Transparent">
 
             <StackPanel
-                Margin="4,0,0,0"
-                VerticalAlignment="Center"
+                Margin="4,4,4,0"
+                VerticalAlignment="Stretch"
                 Orientation="Horizontal">
 
                 <!--  back to main application button (same one the widget window carries)  -->
                 <Button
                     Width="32"
-                    Height="22"
                     Padding="0"
+                    VerticalAlignment="Stretch"
                     Click="BackToDashboard_Click"
                     Style="{StaticResource SubtleButtonStyle}"
                     ToolTipService.ToolTip="Back to Main Application">
@@ -45,11 +45,11 @@
                         Glyph="&#xE944;" />
                 </Button>
 
-                <!--<TextBlock
-                    Margin="6,0,0,0"
+                <TextBlock
+                    Margin="4,0,0,0"
                     VerticalAlignment="Center"
                     Style="{ThemeResource CaptionTextBlockStyle}"
-                    Text="CSV Logging" />-->
+                    Text="CSV Logging" />
             </StackPanel>
         </Grid>
 
@@ -59,15 +59,15 @@
         <StackPanel
             x:Name="UpperRegion"
             Grid.Row="1"
-            Margin="4,0,4,5"
+            Margin="4,0,4,4"
             Spacing="4">
 
             <!--  main bar: start and stop share one slot, only one of them is ever up  -->
             <!--
-                (SubtleButtonStyle is the command bar button as a plain Button; its states resolve to the same
-                brushes AppBarButton uses, so it stretches the way any other button does)
+                (SubtleBarButtonStyle carries the state brushes of the platform subtle button without its border
+                animation, so these stretch the way any other button does)
             -->
-            <Grid Height="32" ColumnSpacing="4">
+            <Grid Height="36" ColumnSpacing="4">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
@@ -76,12 +76,13 @@
 
                 <Button
                     Grid.Column="0"
+                    Padding="8,0,11,0"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Stretch"
                     HorizontalContentAlignment="Left"
                     Click="StartLogging_Click"
                     IsEnabled="{x:Bind ViewModel.CanStart, Mode=OneWay}"
-                    Style="{StaticResource SubtleButtonStyle}"
+                    Style="{StaticResource SubtleBarButtonStyle}"
                     Visibility="{x:Bind ViewModel.StartButtonVisibility, Mode=OneWay}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontSize="14" Glyph="&#xE768;" />
@@ -91,11 +92,12 @@
 
                 <Button
                     Grid.Column="0"
+                    Padding="8,0,11,0"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Stretch"
                     HorizontalContentAlignment="Left"
                     Click="StopLogging_Click"
-                    Style="{StaticResource SubtleButtonStyle}"
+                    Style="{StaticResource SubtleBarButtonStyle}"
                     Visibility="{x:Bind ViewModel.StopButtonVisibility, Mode=OneWay}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontSize="14" Glyph="&#xE71A;" />
@@ -106,13 +108,14 @@
                 <!--  raw running clock  -->
                 <TextBlock
                     Grid.Column="1"
-                    Margin="2,0,2,0"
+                    Margin="4,0,4,0"
                     VerticalAlignment="Center"
                     FontSize="{ThemeResource ControlContentThemeFontSize}"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Text="{x:Bind ViewModel.ElapsedRowsText, Mode=OneWay}"
                     Typography.NumeralAlignment="Tabular" />
 
+                <!--  collapses the lower region  -->
                 <Button
                     x:Name="ToggleDetailsButton"
                     Grid.Column="2"
@@ -120,7 +123,7 @@
                     Padding="0"
                     VerticalAlignment="Stretch"
                     Click="ToggleDetails_Click"
-                    Style="{StaticResource SubtleButtonStyle}">
+                    Style="{StaticResource SubtleBarButtonStyle}">
                     <FontIcon x:Name="ToggleDetailsIcon" FontSize="12" />
                 </Button>
             </Grid>

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
@@ -45,11 +45,11 @@
                         Glyph="&#xE944;" />
                 </Button>
 
-                <TextBlock
+                <!--<TextBlock
                     Margin="6,0,0,0"
                     VerticalAlignment="Center"
                     Style="{ThemeResource CaptionTextBlockStyle}"
-                    Text="CSV Logging" />
+                    Text="CSV Logging" />-->
             </StackPanel>
         </Grid>
 
@@ -63,44 +63,64 @@
             Spacing="4">
 
             <!--  main bar: start and stop share one slot, only one of them is ever up  -->
-            <Grid ColumnSpacing="4">
+            <!--
+                (SubtleButtonStyle is the command bar button as a plain Button; its states resolve to the same
+                brushes AppBarButton uses, so it stretches the way any other button does)
+            -->
+            <Grid Height="32" ColumnSpacing="4">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
                 <Button
                     Grid.Column="0"
-                    HorizontalAlignment="Stretch"
-                    HorizontalContentAlignment="Center"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Stretch"
+                    HorizontalContentAlignment="Left"
                     Click="StartLogging_Click"
                     IsEnabled="{x:Bind ViewModel.CanStart, Mode=OneWay}"
+                    Style="{StaticResource SubtleButtonStyle}"
                     Visibility="{x:Bind ViewModel.StartButtonVisibility, Mode=OneWay}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontSize="14" Glyph="&#xE768;" />
-                        <TextBlock Text="Start logging" />
+                        <TextBlock Text="Start" />
                     </StackPanel>
                 </Button>
 
                 <Button
                     Grid.Column="0"
-                    HorizontalAlignment="Stretch"
-                    HorizontalContentAlignment="Center"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Stretch"
+                    HorizontalContentAlignment="Left"
                     Click="StopLogging_Click"
+                    Style="{StaticResource SubtleButtonStyle}"
                     Visibility="{x:Bind ViewModel.StopButtonVisibility, Mode=OneWay}">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <FontIcon FontSize="14" Glyph="&#xE71A;" />
-                        <TextBlock Text="Stop logging" />
+                        <TextBlock Text="Stop" />
                     </StackPanel>
                 </Button>
 
+                <!--  raw running clock  -->
+                <TextBlock
+                    Grid.Column="1"
+                    Margin="2,0,2,0"
+                    VerticalAlignment="Center"
+                    FontSize="{ThemeResource ControlContentThemeFontSize}"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="{x:Bind ViewModel.ElapsedRowsText, Mode=OneWay}"
+                    Typography.NumeralAlignment="Tabular" />
+
                 <Button
                     x:Name="ToggleDetailsButton"
-                    Grid.Column="1"
+                    Grid.Column="2"
                     Width="36"
                     Padding="0"
                     VerticalAlignment="Stretch"
-                    Click="ToggleDetails_Click">
+                    Click="ToggleDetails_Click"
+                    Style="{StaticResource SubtleButtonStyle}">
                     <FontIcon x:Name="ToggleDetailsIcon" FontSize="12" />
                 </Button>
             </Grid>
@@ -144,7 +164,7 @@
                     VerticalSpacing="8">
 
                     <!--  running time  -->
-                    <StackPanel Width="Auto" Spacing="2">
+                    <!--<StackPanel Width="Auto" Spacing="2">
                         <TextBlock
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Style="{ThemeResource CaptionTextBlockStyle}"
@@ -154,10 +174,10 @@
                             Style="{ThemeResource BodyTextBlockStyle}"
                             Text="{x:Bind ViewModel.ElapsedText, Mode=OneWay}"
                             TextWrapping="Wrap" />
-                    </StackPanel>
+                    </StackPanel>-->
 
                     <!--  number of recorded rows  -->
-                    <StackPanel Width="Auto" Spacing="2">
+                    <!--<StackPanel Width="Auto" Spacing="2">
                         <TextBlock
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Style="{ThemeResource CaptionTextBlockStyle}"
@@ -167,7 +187,7 @@
                             Style="{ThemeResource BodyTextBlockStyle}"
                             Text="{x:Bind ViewModel.RowCountText, Mode=OneWay}"
                             TextWrapping="Wrap" />
-                    </StackPanel>
+                    </StackPanel>-->
 
                     <!--  number of pinned sensors  -->
                     <StackPanel Width="Auto" Spacing="2">
@@ -181,6 +201,19 @@
                             Text="{x:Bind ViewModel.SensorCountText, Mode=OneWay}"
                             TextWrapping="Wrap" />
                     </StackPanel>
+
+                    <!--  polling rate  -->
+                    <StackPanel Width="Auto" Spacing="2">
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource CaptionTextBlockStyle}"
+                            Text="Polling Rate"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            Text="{x:Bind ViewModel.PollingText, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
                 </controls:WrapPanel>
 
                 <!--  save location  -->
@@ -189,30 +222,49 @@
                     (MinHeight is the height a default Button ends up at in the main bar, spelled out here so
                     both bars stay the same even though this one carries smaller text)
                 -->
-                <Button
-                    MinHeight="32"
-                    HorizontalAlignment="Stretch"
-                    HorizontalContentAlignment="Left"
-                    Click="PickLogFolder_Click"
-                    ToolTipService.ToolTip="{x:Bind ViewModel.LogFolderText, Mode=OneWay}">
-                    <Grid ColumnSpacing="8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
+                <Grid ColumnSpacing="4">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
 
-                        <FontIcon
-                            Grid.Column="0"
-                            FontSize="14"
-                            Glyph="&#xE8B7;" />
-                        <TextBlock
-                            Grid.Column="1"
-                            VerticalAlignment="Center"
-                            Style="{ThemeResource CaptionTextBlockStyle}"
-                            Text="{x:Bind ViewModel.LogFolderText, Mode=OneWay}"
-                            TextTrimming="CharacterEllipsis" />
-                    </Grid>
-                </Button>
+                    <Button
+                        Grid.Column="0"
+                        MinHeight="32"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Left"
+                        Click="PickLogFolder_Click"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.LogFolderText, Mode=OneWay}">
+                        <Grid ColumnSpacing="8">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <FontIcon
+                                Grid.Column="0"
+                                FontSize="14"
+                                Glyph="&#xE8B7;" />
+                            <TextBlock
+                                Grid.Column="1"
+                                VerticalAlignment="Center"
+                                Style="{ThemeResource CaptionTextBlockStyle}"
+                                Text="{x:Bind ViewModel.LogFolderText, Mode=OneWay}"
+                                TextTrimming="CharacterEllipsis" />
+                        </Grid>
+                    </Button>
+
+                    <!--  opens the same folder in the shell, silently doing nothing while it does not exist yet  -->
+                    <Button
+                        Grid.Column="1"
+                        Width="36"
+                        Padding="0"
+                        VerticalAlignment="Stretch"
+                        Click="OpenLogFolder_Click"
+                        ToolTipService.ToolTip="Open in File Explorer">
+                        <FontIcon FontSize="14" Glyph="&#xED25;" />
+                    </Button>
+                </Grid>
             </StackPanel>
         </Grid>
     </Grid>

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
@@ -74,6 +74,7 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
+                <!--  start button  -->
                 <Button
                     Grid.Column="0"
                     Padding="8,0,11,0"
@@ -90,20 +91,31 @@
                     </StackPanel>
                 </Button>
 
-                <Button
-                    Grid.Column="0"
-                    Padding="8,0,11,0"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Stretch"
-                    HorizontalContentAlignment="Left"
-                    Click="StopLogging_Click"
-                    Style="{StaticResource SubtleBarButtonStyle}"
-                    Visibility="{x:Bind ViewModel.StopButtonVisibility, Mode=OneWay}">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+
+                    <!--  stop button  -->
+                    <Button
+                        Width="36"
+                        Padding="0"
+                        VerticalAlignment="Stretch"
+                        Click="StopLogging_Click"
+                        Style="{StaticResource SubtleBarButtonStyle}"
+                        Visibility="{x:Bind ViewModel.StopButtonVisibility, Mode=OneWay}">
                         <FontIcon FontSize="14" Glyph="&#xE71A;" />
-                        <TextBlock Text="Stop" />
-                    </StackPanel>
-                </Button>
+                    </Button>
+
+                    <!--  pause button  -->
+                    <!--  (holds the recording without closing the file)  -->
+                    <Button
+                        Width="36"
+                        Padding="0"
+                        VerticalAlignment="Stretch"
+                        Click="TogglePause_Click"
+                        Style="{StaticResource SubtleBarButtonStyle}"
+                        Visibility="{x:Bind ViewModel.PauseButtonVisibility, Mode=OneWay}">
+                        <FontIcon FontSize="12" Glyph="{x:Bind ViewModel.PauseGlyph, Mode=OneWay}" />
+                    </Button>
+                </StackPanel>
 
                 <!--  raw running clock  -->
                 <TextBlock
@@ -115,7 +127,7 @@
                     Text="{x:Bind ViewModel.ElapsedRowsText, Mode=OneWay}"
                     Typography.NumeralAlignment="Tabular" />
 
-                <!--  collapses the lower region  -->
+                <!--  toggle details button  -->
                 <Button
                     x:Name="ToggleDetailsButton"
                     Grid.Column="2"
@@ -175,7 +187,7 @@
                             TextWrapping="Wrap" />
                         <TextBlock
                             Style="{ThemeResource BodyTextBlockStyle}"
-                            Text="{x:Bind ViewModel.ElapsedText, Mode=OneWay}"
+                            Text="{x:Bind ViewModel.RecordedElapsedText, Mode=OneWay}"
                             TextWrapping="Wrap" />
                     </StackPanel>-->
 
@@ -210,11 +222,39 @@
                         <TextBlock
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Style="{ThemeResource CaptionTextBlockStyle}"
-                            Text="Polling Rate"
+                            Text="Polling rate"
                             TextWrapping="Wrap" />
                         <TextBlock
                             Style="{ThemeResource BodyTextBlockStyle}"
                             Text="{x:Bind ViewModel.PollingText, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+
+                    <!--  wall clock since start, pauses included  -->
+                    <!--  (the main bar shows the recorded stretch instead; this is the one that matches the
+                          elapsed column in the file)  -->
+                    <StackPanel Width="Auto" Spacing="2">
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource CaptionTextBlockStyle}"
+                            Text="Total elapsed"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            Text="{x:Bind ViewModel.TotalElapsedText, Mode=OneWay}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+
+                    <!--  what explains the difference between the two durations  -->
+                    <StackPanel Width="Auto" Spacing="2">
+                        <TextBlock
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource CaptionTextBlockStyle}"
+                            Text="Pauses"
+                            TextWrapping="Wrap" />
+                        <TextBlock
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            Text="{x:Bind ViewModel.PauseCountText, Mode=OneWay}"
                             TextWrapping="Wrap" />
                     </StackPanel>
                 </controls:WrapPanel>

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Window
+    x:Class="FluentSensors.Features.CsvLogging.CsvLoggerWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="Fluent Sensors"
+    mc:Ignorable="d">
+
+    <Grid x:Name="RootGrid" Background="Transparent">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+
+        <!--  custom title bar  -->
+        <!--  (empty space stays the drag region, the system caption buttons sit on the right)  -->
+        <Grid
+            x:Name="CustomTitleBar"
+            Grid.Row="0"
+            Height="32"
+            Background="Transparent">
+
+            <StackPanel
+                Margin="4,0,0,0"
+                VerticalAlignment="Center"
+                Orientation="Horizontal">
+
+                <!--  back to main application button (same one the widget window carries)  -->
+                <Button
+                    Width="32"
+                    Height="22"
+                    Padding="0"
+                    Click="BackToDashboard_Click"
+                    Style="{StaticResource SubtleButtonStyle}"
+                    ToolTipService.ToolTip="Back to Main Application">
+                    <FontIcon
+                        FontSize="14"
+                        FontWeight="SemiLight"
+                        Glyph="&#xE944;" />
+                </Button>
+
+                <TextBlock
+                    Margin="6,0,0,0"
+                    VerticalAlignment="Center"
+                    Style="{ThemeResource CaptionTextBlockStyle}"
+                    Text="CSV Logging" />
+            </StackPanel>
+        </Grid>
+
+
+        <!--  upper region: the recording action plus the status line  -->
+        <!--  (margins live on the two regions instead of the whole content, so the divider below can run edge to edge)  -->
+        <StackPanel
+            x:Name="UpperRegion"
+            Grid.Row="1"
+            Margin="4,0,4,4"
+            Spacing="4">
+
+            <!--  main bar: start and stop share one slot, only one of them is ever up  -->
+            <Grid ColumnSpacing="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <Button
+                    Grid.Column="0"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Center"
+                    Click="StartLogging_Click"
+                    Content="Start logging"
+                    IsEnabled="{x:Bind ViewModel.CanStart, Mode=OneWay}"
+                    Style="{ThemeResource AccentButtonStyle}"
+                    Visibility="{x:Bind ViewModel.StartButtonVisibility, Mode=OneWay}" />
+
+                <Button
+                    Grid.Column="0"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Center"
+                    Click="StopLogging_Click"
+                    Content="Stop logging"
+                    Visibility="{x:Bind ViewModel.StopButtonVisibility, Mode=OneWay}" />
+
+                <Button
+                    x:Name="ToggleDetailsButton"
+                    Grid.Column="1"
+                    Width="36"
+                    Padding="0"
+                    VerticalAlignment="Stretch"
+                    Click="ToggleDetails_Click">
+                    <FontIcon x:Name="ToggleDetailsIcon" FontSize="12" />
+                </Button>
+            </Grid>
+
+            <TextBlock
+                x:Name="StatusTextBlock"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                Style="{ThemeResource CaptionTextBlockStyle}"
+                Text="{x:Bind ViewModel.StatusText, Mode=OneWay}"
+                TextWrapping="Wrap" />
+        </StackPanel>
+
+
+        <!--  divider  -->
+        <!--  (deliberately without a margin so it touches both window edges)  -->
+        <Border
+            Grid.Row="2"
+            Height="1"
+            HorizontalAlignment="Stretch"
+            Background="{ThemeResource DividerStrokeColorDefaultBrush}" />
+
+
+        <!--  lower region  -->
+        <!--  the live readout and the save location, collapsed together by the chevron above  -->
+        <StackPanel
+            x:Name="LowerRegion"
+            Grid.Row="3"
+            Margin="4,10,4,12"
+            Background="{ThemeResource LayerFillColorDefaultBrush}"
+            Spacing="12">
+
+            <!--  (same label above value shape the hardware view info panels use)  -->
+            <controls:WrapPanel
+                Padding="4"
+                HorizontalSpacing="12"
+                VerticalSpacing="12">
+                <StackPanel Width="Auto" Spacing="2">
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="Pinned sensors"
+                        TextWrapping="Wrap" />
+                    <TextBlock
+                        Style="{ThemeResource BodyTextBlockStyle}"
+                        Text="{x:Bind ViewModel.SensorCountText, Mode=OneWay}"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+
+                <StackPanel Width="Auto" Spacing="2">
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="Running for"
+                        TextWrapping="Wrap" />
+                    <TextBlock
+                        Style="{ThemeResource BodyTextBlockStyle}"
+                        Text="{x:Bind ViewModel.ElapsedText, Mode=OneWay}"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+
+                <StackPanel Width="Auto" Spacing="2">
+                    <TextBlock
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="Recorded rows"
+                        TextWrapping="Wrap" />
+                    <TextBlock
+                        Style="{ThemeResource BodyTextBlockStyle}"
+                        Text="{x:Bind ViewModel.RowCountText, Mode=OneWay}"
+                        TextWrapping="Wrap" />
+                </StackPanel>
+            </controls:WrapPanel>
+
+            <!--  save location  -->
+            <!--  (picked up front so start never has to ask)  -->
+            <Button
+                HorizontalAlignment="Stretch"
+                HorizontalContentAlignment="Left"
+                Click="PickLogFolder_Click"
+                ToolTipService.ToolTip="{x:Bind ViewModel.LogFolderText, Mode=OneWay}">
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <FontIcon
+                        Grid.Column="0"
+                        FontSize="14"
+                        Glyph="&#xE8B7;" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Style="{ThemeResource CaptionTextBlockStyle}"
+                        Text="{x:Bind ViewModel.LogFolderText, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis" />
+                </Grid>
+            </Button>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
@@ -364,6 +364,11 @@ namespace FluentSensors.Features.CsvLogging
 
             _appWindow.Hide();
             ViewModel.SetReadoutActive(false);
+
+            // the window survives its own close, so the elapsed clock, the pause count and the row counter of the
+            // last recording would still be up the next time it is opened
+            // (returns early on its own while a recording is running, see above)
+            CsvLoggingService.Instance.ResetCompletedRecording();
         }
 
         private void OnRegionSizeChanged(object sender, SizeChangedEventArgs e)

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace FluentSensors.Features.CsvLogging
         // lower region, hiding the status line, or a wrap panel that breaks into another row all resize correctly
         // without a second hand-tuned number
         // the fallback only ever covers a measure that comes back empty, before the content exists at all
-        private const double WindowWidthDip = 235;
+        private const double WindowWidthDip = 225;
         private const double FallbackWindowHeightDip = 232;
 
         // status line under main bar

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
@@ -6,6 +6,8 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using WinRT;
 
@@ -36,11 +38,13 @@ namespace FluentSensors.Features.CsvLogging
         private AppWindow _appWindow;
         private const string WindowKey = "CsvLogger";
 
-        // fixed window width in XAML DIP; the height is read back off the arranged rows instead, so collapsing the
+        // width the logger opens at when nothing was saved yet, and the narrowest it can be dragged; from there the
+        // width belongs to the user, only the height stays calculated
+        // the height is read back off the arranged rows, so collapsing the
         // lower region, hiding the status line, or a wrap panel that breaks into another row all resize correctly
         // without a second hand-tuned number
         // the fallback only ever covers a measure that comes back empty, before the content exists at all
-        private const double WindowWidthDip = 240;
+        private const double WindowWidthDip = 220;
         private const double FallbackWindowHeightDip = 232;
 
         // status line under main bar
@@ -86,7 +90,7 @@ namespace FluentSensors.Features.CsvLogging
             presenter.IsAlwaysOnTop = true; // same as the widget, a running recording has to stay readable over other apps
             presenter.IsMaximizable = false;
             presenter.IsMinimizable = true;
-            presenter.IsResizable = false;
+            presenter.IsResizable = true; // width only, the height is pinned to the content in ApplyWindowSize
             _appWindow.SetPresenter(presenter);
 
             // content state has to be applied before the first measure, both the status line and the expand state
@@ -98,6 +102,7 @@ namespace FluentSensors.Features.CsvLogging
             UpperRegion.Spacing = ShowStatusLine ? UpperRegion.Spacing : 0;
 
             ApplyExpandState();
+            ApplyInitialWidth();
 
             // window size and position:
             // the width is fixed and the height comes from the content, only the position is restored, and only
@@ -377,6 +382,12 @@ namespace FluentSensors.Features.CsvLogging
                 bool isMinimized = sender.Presenter is OverlappedPresenter presenter &&
                                    presenter.State == OverlappedPresenterState.Minimized;
                 ViewModel.SetReadoutActive(!isMinimized);
+
+                // a width the user dragged has to survive the next launch, same as the position below
+                if (!isMinimized && this.AppWindow.IsVisible)
+                {
+                    SaveWindowState();
+                }
             }
 
             if (args.DidPositionChange && this.AppWindow.IsVisible)
@@ -407,6 +418,25 @@ namespace FluentSensors.Features.CsvLogging
             ApplyExpandState();
             ApplyWindowSize();
             SaveWindowState();
+        }
+
+        // hands the folder to the shell
+        // a folder that does not exist yet is not created here; the first start does that when it actually writes,
+        // so this does nothing rather than leaving empty folders behind
+        private void OpenLogFolder_Click(object sender, RoutedEventArgs e)
+        {
+            string folder = ViewModel.LogFolderText;
+            if (string.IsNullOrEmpty(folder) || !Directory.Exists(folder)) return;
+
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = folder,
+                    UseShellExecute = true
+                });
+            }
+            catch { /* no handler registered for the path, nothing to do about that from here */ }
         }
 
         private void PickLogFolder_Click(object sender, RoutedEventArgs e)
@@ -549,7 +579,25 @@ namespace FluentSensors.Features.CsvLogging
             return measured > 0 ? measured : FallbackWindowHeightDip;
         }
 
-        // sizes the window to exactly the content it has
+        // opens at the saved width, or at the design width when there is nothing usable saved
+        // runs once from the constructor; every later width comes from the user dragging an edge
+        private void ApplyInitialWidth()
+        {
+            double scaleFactor = GetScaleFactor();
+            int frameWidthPx = Math.Max(0, _appWindow.Size.Width - _appWindow.ClientSize.Width);
+            int defaultWidthPx = (int)Math.Round(WindowWidthDip * scaleFactor) + frameWidthPx;
+
+            // the design width doubles as the lower bound; the readout below the divider starts dropping items onto
+            // extra rows below it and the status line turns into a paragraph
+            WinUIEx.WindowManager.Get(this).MinWidth = defaultWidthPx / scaleFactor;
+
+            var savedState = WindowStateService.Instance.GetState(WindowKey);
+            int widthPx = savedState != null && savedState.Width > defaultWidthPx ? savedState.Width : defaultWidthPx;
+
+            _appWindow.Resize(new Windows.Graphics.SizeInt32(widthPx, _appWindow.Size.Height));
+        }
+
+        // pins the window height to the content, leaving the width alone
         private void ApplyWindowSize()
         {
             if (_isApplyingSize) return;
@@ -562,23 +610,17 @@ namespace FluentSensors.Features.CsvLogging
                 // how much bigger the window is than its client area, read off the window rather than assumed:
                 // ExtendsContentIntoTitleBar pulls the caption into the client area, so the caption height must not
                 // be added on top of the content the way a plain frame calculation would
-                int frameWidthPx = Math.Max(0, _appWindow.Size.Width - _appWindow.ClientSize.Width);
                 int frameHeightPx = Math.Max(0, _appWindow.Size.Height - _appWindow.ClientSize.Height);
-                int widthPx = (int)Math.Round(WindowWidthDip * scaleFactor) + frameWidthPx;
+                int heightPx = (int)Math.Round(ContentHeightDip() * scaleFactor) + frameHeightPx;
 
-                // the width has to be in place before the height is read; the readout wraps onto a second row at
-                // narrow widths, so reading the height at the old window width would report one the window never
-                // ends up having
-                if (_appWindow.Size.Width != widthPx)
-                {
-                    _appWindow.Resize(new Windows.Graphics.SizeInt32(widthPx, _appWindow.Size.Height));
-                }
+                // holds the height through an interactive resize: these end up in WM_GETMINMAXINFO, and the track
+                // sizes there are what the system clamps a drag against, so dragging an edge can only change the
+                // width while this keeps following the content
+                var manager = WinUIEx.WindowManager.Get(this);
+                manager.MinHeight = heightPx / scaleFactor;
+                manager.MaxHeight = heightPx / scaleFactor;
 
-                double heightDip = ContentHeightDip();
-
-                _appWindow.Resize(new Windows.Graphics.SizeInt32(
-                    widthPx,
-                    (int)Math.Round(heightDip * scaleFactor) + frameHeightPx));
+                _appWindow.Resize(new Windows.Graphics.SizeInt32(_appWindow.Size.Width, heightPx));
             }
             finally
             {

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
@@ -1,0 +1,746 @@
+using Microsoft.UI.Composition;
+using Microsoft.UI.Composition.SystemBackdrops;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using WinRT;
+
+using FluentSensors.Controls.SensorRow;
+using FluentSensors.Features.TaskbarWidget;
+using FluentSensors.Persistence.Models;
+using FluentSensors.Persistence.Services;
+
+
+namespace FluentSensors.Features.CsvLogging
+{
+    // small always-on-top readout for a csv recording: start, stop, and how long it has been running, how many
+    // sensors it covers and how many rows it has written so far
+    //
+    // chrome, backdrop and the retained-instance lifecycle are the same recipe WidgetWindow uses; there is no shared
+    // window base in this project, every window carries its own copy
+    public sealed partial class CsvLoggerWindow : Window
+    {
+        // === win32 api imports ===
+
+        // import the Windows-API to calculate the screen scaling (100%, 125%, 150% etc.)
+        [DllImport("user32.dll")]
+        private static extern uint GetDpiForWindow(IntPtr hwnd);
+
+
+        // === fields ===
+
+        private AppWindow _appWindow;
+        private const string WindowKey = "CsvLogger";
+
+        // fixed window width in XAML DIP; the height is always measured from the content instead, so collapsing the
+        // lower region, hiding the status line, or a wrap panel that breaks into another row all resize correctly
+        // without a second hand-tuned number
+        private const double WindowWidthDip = 240;
+        private const double FallbackWindowHeightDip = 232;
+
+        // status line under main bar
+        private const bool ShowStatusLine = false;
+
+        // whether the lower region (readout and save location) is currently shown; pure view state, the recording
+        // itself does not care
+        private bool _isExpanded = true;
+
+        public CsvLoggerViewModel ViewModel { get; }
+        public static CsvLoggerWindow CurrentInstance { get; private set; }
+        private static CsvLoggerWindow _retainedInstance;
+
+        private bool _isClosed = false;
+        private static bool _isRecreating = false;
+
+        // system backdrop controllers and configuration
+        private DesktopAcrylicController _acrylicController;
+        private MicaController _micaController;
+        private SystemBackdropConfiguration _configurationSource;
+        private Windows.UI.ViewManagement.UISettings? _uiSettings;
+
+
+        // === constructor ===
+
+        public CsvLoggerWindow()
+        {
+            // initialization
+            ViewModel = new CsvLoggerViewModel();
+            this.InitializeComponent();
+            this.AppWindow.SetIcon("Assets\\Icon\\Icon.ico");
+            CurrentInstance = this;
+
+            // window configuration
+            _appWindow = this.AppWindow;
+            ExtendsContentIntoTitleBar = true;
+            SetTitleBar(CustomTitleBar);
+            var presenter = OverlappedPresenter.Create();
+            presenter.IsAlwaysOnTop = true; // same as the widget, a running recording has to stay readable over other apps
+            presenter.IsMaximizable = false;
+            presenter.IsMinimizable = true;
+            presenter.IsResizable = false;
+            _appWindow.SetPresenter(presenter);
+
+            // content state has to be applied before the first measure, both the status line and the expand state
+            // change how tall the window ends up
+            StatusTextBlock.Visibility = ShowStatusLine ? Visibility.Visible : Visibility.Collapsed;
+            ApplyExpandState();
+
+            // window size and position:
+            // the width is fixed and the height comes from the content, only the position is restored, and only
+            // when it still lands on a connected monitor; without a usable saved position Windows places the
+            // window itself
+            ApplyWindowSize();
+            RestoreWindowPosition();
+            SaveWindowState();
+
+            // theming
+            SetBackdrop(SettingsService.Instance.BackdropType);
+            ApplyTheme(SettingsService.Instance.AppTheme);
+
+            // event routing
+            SettingsService.Instance.ThemeChanged += OnThemeChanged;
+            SettingsService.Instance.BackdropTypeChanged += OnBackdropTypeChanged;
+            SettingsService.Instance.OpacityChanged += OnOpacityChanged;
+            SettingsService.Instance.TintColorChanged += OnTintColorChanged;
+
+            try
+            {
+                _uiSettings = new Windows.UI.ViewManagement.UISettings();
+                TaskbarFlyoutWindow.SeedSystemVisualsSnapshot(_uiSettings);
+                _uiSettings.AdvancedEffectsEnabledChanged += OnSystemVisualSettingsChanged;
+                _uiSettings.ColorValuesChanged += OnSystemVisualSettingsChanged;
+            }
+            catch { }
+
+            // the status line is the one piece of content whose height is not fixed, a long file name wraps it onto
+            // another line; re-measuring on every change keeps the window exactly as tall as it needs to be
+            ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+
+            this.Closed += CsvLoggerWindow_Closed;
+            _appWindow.Changed += AppWindow_Changed;
+            _appWindow.Closing += AppWindow_Closing;
+
+            KickBackdropRefresh();
+        }
+
+
+        // === public methods ===
+
+        // opens the logger with the given sensors, reusing the previously hidden window instance if one exists
+        // instead of creating a new one every time (see _retainedInstance), same pattern as WidgetWindow
+        //
+        // a running recording keeps the sensor set it started with; its columns are already written into the open
+        // files header, so the push is dropped and the window only says why
+        public static void ShowWithSensors(List<SensorRowViewModel> selectedSensors)
+        {
+            bool isSelectionLocked = CsvLoggingService.Instance.IsRunning;
+            if (!isSelectionLocked)
+            {
+                CsvLoggingService.Instance.SetSensors(selectedSensors);
+            }
+
+            // logger is already open: nothing to build, just bring it back up
+            if (CurrentInstance != null)
+            {
+                if (isSelectionLocked)
+                {
+                    CurrentInstance.ViewModel.ShowSelectionLockedHint();
+                }
+
+                CurrentInstance.RestoreAndActivate();
+                return;
+            }
+
+            // logger was previously hidden (closed via the X button): reuse that native window instead of creating
+            // a new one
+            if (_retainedInstance != null)
+            {
+                var window = _retainedInstance;
+                _retainedInstance = null;
+                CurrentInstance = window;
+
+                window.ViewModel.SetReadoutActive(true);
+                if (isSelectionLocked)
+                {
+                    window.ViewModel.ShowSelectionLockedHint();
+                }
+
+                window.RestoreAndActivate();
+                return;
+            }
+
+            // no logger has been created this session yet: build a fresh native window
+            var newWindow = new CsvLoggerWindow();
+            if (isSelectionLocked)
+            {
+                newWindow.ViewModel.ShowSelectionLockedHint();
+            }
+            newWindow.Activate();
+        }
+
+        public void SafeDestroy()
+        {
+            if (_isClosed) return;
+            _isClosed = true;
+
+            try
+            {
+                SettingsService.Instance.ThemeChanged -= OnThemeChanged;
+                SettingsService.Instance.BackdropTypeChanged -= OnBackdropTypeChanged;
+                SettingsService.Instance.OpacityChanged -= OnOpacityChanged;
+                SettingsService.Instance.TintColorChanged -= OnTintColorChanged;
+            }
+            catch { }
+
+            try
+            {
+                if (_uiSettings != null)
+                {
+                    _uiSettings.AdvancedEffectsEnabledChanged -= OnSystemVisualSettingsChanged;
+                    _uiSettings.ColorValuesChanged -= OnSystemVisualSettingsChanged;
+                    _uiSettings = null;
+                }
+            }
+            catch { }
+
+            // AppWindow_Closing cancels the close and re-registers this instance as _retainedInstance; detaching it
+            // here is what lets the Close below go through instead of resurrecting a window that is already torn down
+            // CsvLoggerWindow_Closed stays attached, it carries the real teardown once the close completes
+            try
+            {
+                _appWindow.Closing -= AppWindow_Closing;
+                _appWindow.Changed -= AppWindow_Changed;
+                ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            }
+            catch { }
+
+            try
+            {
+                _acrylicController?.Dispose();
+                _acrylicController = null;
+                _micaController?.Dispose();
+                _micaController = null;
+                this.Close();
+            }
+            catch { }
+        }
+
+        // fully destroys and recreates the logger window when Windows global transparency or theme is toggled
+        //
+        // safe to do mid-recording: CsvLoggingService owns the open file and the counters, the rebuilt window just
+        // reads them again
+        public static void RecreateWindow()
+        {
+            if (_isRecreating) return;
+            if (CurrentInstance == null && _retainedInstance == null) return;
+            _isRecreating = true;
+
+            bool wasVisible = CurrentInstance != null && CurrentInstance._appWindow != null && CurrentInstance._appWindow.IsVisible;
+
+            if (CurrentInstance != null)
+            {
+                var old = CurrentInstance;
+                CurrentInstance = null;
+                old.SafeDestroy();
+            }
+
+            if (_retainedInstance != null)
+            {
+                var old = _retainedInstance;
+                _retainedInstance = null;
+                old.SafeDestroy();
+            }
+
+            if (wasVisible)
+            {
+                // the queue needs a fallback: closing the main window to the tray leaves MainWindow.CurrentInstance
+                // null, and a null-conditional TryEnqueue there would skip the finally below and latch _isRecreating
+                // for the rest of the session, so the logger would never rebuild again
+                var queue = MainWindow.CurrentInstance?.DispatcherQueue ?? DispatcherQueue.GetForCurrentThread();
+                bool queued = queue != null && queue.TryEnqueue(() =>
+                {
+                    try
+                    {
+                        var window = new CsvLoggerWindow();
+                        window.Activate();
+                    }
+                    finally
+                    {
+                        _isRecreating = false;
+                    }
+                });
+
+                if (!queued)
+                {
+                    _isRecreating = false;
+                }
+            }
+            else
+            {
+                _isRecreating = false;
+            }
+        }
+
+
+        // === lifecycle ===
+
+        private void CsvLoggerWindow_Closed(object sender, WindowEventArgs args)
+        {
+            SaveWindowState();
+
+            // we detach the event handlers from the settings service
+            SettingsService.Instance.BackdropTypeChanged -= OnBackdropTypeChanged;
+            SettingsService.Instance.OpacityChanged -= OnOpacityChanged;
+            SettingsService.Instance.TintColorChanged -= OnTintColorChanged;
+            SettingsService.Instance.ThemeChanged -= OnThemeChanged;
+
+            ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            ViewModel.Cleanup();
+
+            _acrylicController?.Dispose();
+            _acrylicController = null;
+            _micaController?.Dispose();
+            _micaController = null;
+
+            this.Activated -= Window_Activated;
+            _configurationSource = null;
+            CurrentInstance = null;
+        }
+
+        private void Window_Activated(object sender, WindowActivatedEventArgs args)
+        {
+            if (_configurationSource != null)
+            {
+                // always render the active blur, otherwise clicking outside the logger drops it to the inactive
+                // material while it is still sitting on top of everything
+                _configurationSource.IsInputActive = true;
+            }
+        }
+
+        // --- memory leak: CsvLoggerWindow never released after close ---
+        // problem: WinUI 3 never releases secondary Window objects back to the GC/OS after a real close
+        // confirmed, still-open platform bug, reproducible even with empty window content:
+        // https://github.com/microsoft/microsoft-ui-xaml/issues/9063
+        // fix: hide instead of actually closing, and keep this instance around (_retainedInstance) for reuse the next
+        // time the logger is opened
+        // same approach as WidgetWindow and HiddenSensorsWindow
+        //
+        // a running recording is deliberately left alone here; it lives in CsvLoggingService, so closing the readout
+        // only stops the readout, never the logging
+        private void AppWindow_Closing(AppWindow sender, AppWindowClosingEventArgs args)
+        {
+            // SafeDestroy is tearing this instance down: let the close proceed instead of handing a window with
+            // _isClosed set back to _retainedInstance, where every later SetBackdrop and ApplyTheme returns early
+            if (_isClosed) return;
+
+            args.Cancel = true;
+
+            SaveWindowState();
+            CurrentInstance = null;
+            _retainedInstance = this;
+
+            _appWindow.Hide();
+            ViewModel.SetReadoutActive(false);
+        }
+
+        private void OnViewModelPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(CsvLoggerViewModel.StatusText)) return;
+            if (_isClosed) return;
+
+            ApplyWindowSize();
+        }
+
+        private void AppWindow_Changed(AppWindow sender, AppWindowChangedEventArgs args)
+        {
+            // minimize/restore never sets DidPresenterChange, that one only fires when the Presenter itself is
+            // swapped; a state change within the same OverlappedPresenter shows up as DidSizeChange instead
+            if (args.DidSizeChange)
+            {
+                bool isMinimized = sender.Presenter is OverlappedPresenter presenter &&
+                                   presenter.State == OverlappedPresenterState.Minimized;
+                ViewModel.SetReadoutActive(!isMinimized);
+            }
+
+            if (args.DidPositionChange && this.AppWindow.IsVisible)
+            {
+                SaveWindowState();
+            }
+        }
+
+
+        // === user interaction ===
+
+        private void StartLogging_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.Start();
+        }
+
+        private void StopLogging_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.Stop();
+        }
+
+        // collapses the window down to the divider, so a running recording can sit on screen as a thin bar with just
+        // the stop button on it
+        private void ToggleDetails_Click(object sender, RoutedEventArgs e)
+        {
+            _isExpanded = !_isExpanded;
+
+            ApplyExpandState();
+            ApplyWindowSize();
+            SaveWindowState();
+        }
+
+        private void PickLogFolder_Click(object sender, RoutedEventArgs e)
+        {
+            // the dialog is owned by this window so it cannot end up behind an always-on-top logger
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            string picked = Win32FileDialogHelper.PickFolder(hwnd, "CSV Logging Folder", ViewModel.LogFolderText);
+            if (picked == null) return; // user cancelled
+
+            ViewModel.SetLogFolder(picked);
+        }
+
+        private void BackToDashboard_Click(object sender, RoutedEventArgs e)
+        {
+            // check if the main window instance exists in memory
+            if (MainWindow.CurrentInstance != null)
+            {
+                MainWindow.CurrentInstance.OpenDashboard();
+            }
+            else
+            {
+                // if the instance was completely destroyed, create a new one
+                // the app process is safely kept alive by the open logger window
+                var newMainWindow = new MainWindow();
+                newMainWindow.Activate();
+            }
+        }
+
+
+        // === settings event listeners and handlers ===
+
+        private void OnThemeChanged(string newTheme)
+        {
+            this.DispatcherQueue.TryEnqueue(() =>
+            {
+                ApplyTheme(newTheme);
+            });
+        }
+
+        private void OnBackdropTypeChanged(string newType)
+        {
+            this.DispatcherQueue.TryEnqueue(() =>
+            {
+                SetBackdrop(newType);
+            });
+        }
+
+        private void OnOpacityChanged(float tintOpacity, float luminosityOpacity)
+        {
+            this.DispatcherQueue.TryEnqueue(() =>
+            {
+                UpdateAcrylicProperties();
+            });
+        }
+
+        private void OnTintColorChanged(bool useAccentColor, Windows.UI.Color customColor)
+        {
+            this.DispatcherQueue.TryEnqueue(() =>
+            {
+                UpdateAcrylicProperties();
+                UpdateSolidBackground();
+            });
+        }
+
+        // a named handler rather than a lambda, so SafeDestroy can detach it again; every rebuilt window subscribes
+        // anew and without the detach the UISettings handler list grows by one per rebuild
+        //
+        // routes to RouteSystemVisualsChange rather than a rebuild directly, so a pure accent change resolves into
+        // an in-place refresh instead
+        private void OnSystemVisualSettingsChanged(Windows.UI.ViewManagement.UISettings sender, object args)
+        {
+            TaskbarFlyoutWindow.RouteSystemVisualsChange(sender);
+        }
+
+
+        // === window sizing and positioning ===
+
+        // converts the screen DPI to a scale factor
+        // (100% = 1.0, 125% = 1.25, etc.)
+        private double GetScaleFactor()
+        {
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            uint dpi = GetDpiForWindow(hwnd);
+            return dpi / 96.0;
+        }
+
+        // shows or hides the lower region and points the chevron at what the next click will do
+        private void ApplyExpandState()
+        {
+            LowerRegion.Visibility = _isExpanded ? Visibility.Visible : Visibility.Collapsed;
+
+            // segoe fluent icons ChevronUp and ChevronDown, escaped rather than pasted so this file stays
+            // plain ascii like the rest of the sources
+            ToggleDetailsIcon.Glyph = _isExpanded ? "\uE70E" : "\uE70D";
+            ToolTipService.SetToolTip(ToggleDetailsButton, _isExpanded ? "Hide details" : "Show details");
+        }
+
+        // measures the content at the fixed window width and sizes the window to exactly that
+        // ResizeClient rather than Resize: with ExtendsContentIntoTitleBar the client area is the whole content, so
+        // this needs no assumption about how thick the window frame currently is
+        private void ApplyWindowSize()
+        {
+            double scaleFactor = GetScaleFactor();
+
+            RootGrid.InvalidateMeasure();
+            RootGrid.Measure(new Windows.Foundation.Size(WindowWidthDip, double.PositiveInfinity));
+
+            // a measure before the content is ready can come back empty; the fallback keeps a usable window instead
+            // of a zero-height one
+            double heightDip = RootGrid.DesiredSize.Height;
+            if (heightDip <= 0) heightDip = FallbackWindowHeightDip;
+
+            _appWindow.ResizeClient(new Windows.Graphics.SizeInt32(
+                (int)(WindowWidthDip * scaleFactor),
+                (int)(heightDip * scaleFactor)));
+        }
+
+        private void RestoreWindowPosition()
+        {
+            var savedState = WindowStateService.Instance.GetState(WindowKey);
+            if (savedState == null) return;
+            if (!IsPositionOnScreen(savedState.X, savedState.Y, _appWindow.Size.Width, _appWindow.Size.Height)) return;
+
+            _appWindow.Move(new Windows.Graphics.PointInt32(savedState.X, savedState.Y));
+        }
+
+        private void RestoreAndActivate()
+        {
+            if (_appWindow.Presenter is OverlappedPresenter presenter)
+            {
+                presenter.Restore();
+            }
+
+            _appWindow.Show();
+            this.Activate();
+        }
+
+        // checks whether the given rect would actually be visible on any currently connected monitor; a saved position
+        // can become stale if the monitor it was on gets disconnected, or the display arrangement changes
+        private bool IsPositionOnScreen(int x, int y, int width, int height)
+        {
+            var rect = new Windows.Graphics.RectInt32(x, y, width, height);
+
+            // indexed loop instead of foreach: iterating DisplayArea.FindAll() with foreach throws an
+            // InvalidCastException due to a WinRT interop bug in its enumerator; indexer access avoids it
+            var displayAreas = DisplayArea.FindAll();
+            for (int i = 0; i < displayAreas.Count; i++)
+            {
+                if (RectsOverlap(rect, displayAreas[i].WorkArea))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private bool RectsOverlap(Windows.Graphics.RectInt32 a, Windows.Graphics.RectInt32 b)
+        {
+            return a.X < b.X + b.Width && a.X + a.Width > b.X &&
+                   a.Y < b.Y + b.Height && a.Y + a.Height > b.Y;
+        }
+
+        // writes the current rect (debounced) to the window state store
+        // WasOpen is deliberately left untouched: unlike the widget, the logger never reopens itself on the next
+        // launch, a recording is always started by hand
+        private void SaveWindowState()
+        {
+            var state = WindowStateService.Instance.GetState(WindowKey) ?? new WindowState();
+
+            // while minimized, Windows reports the windows position as the (-32000, -32000) sentinel value; keep the
+            // last known real rect instead of overwriting it with that garbage
+            bool isMinimized = this.AppWindow.Presenter is OverlappedPresenter presenter &&
+                               presenter.State == OverlappedPresenterState.Minimized;
+            if (!isMinimized)
+            {
+                state.X = _appWindow.Position.X;
+                state.Y = _appWindow.Position.Y;
+                state.Width = _appWindow.Size.Width;
+                state.Height = _appWindow.Size.Height;
+            }
+
+            WindowStateService.Instance.SetState(WindowKey, state);
+        }
+
+
+        // === theme and backdrop application ===
+
+        private void ApplyTheme(string themeTag)
+        {
+            if (_isClosed) return;
+
+            if (this.Content is FrameworkElement rootElement)
+            {
+                rootElement.RequestedTheme = themeTag switch
+                {
+                    "Light" => ElementTheme.Light,
+                    "Dark" => ElementTheme.Dark,
+                    _ => ElementTheme.Default
+                };
+            }
+
+            if (_appWindow != null && _appWindow.TitleBar != null)
+            {
+                _appWindow.TitleBar.PreferredTheme = themeTag switch
+                {
+                    "Light" => TitleBarTheme.Light,
+                    "Dark" => TitleBarTheme.Dark,
+                    _ => TitleBarTheme.UseDefaultAppMode
+                };
+            }
+        }
+
+        private void UpdateAcrylicProperties()
+        {
+            if (_isClosed) return;
+
+            if (_acrylicController != null)
+            {
+                Windows.UI.Color targetColor;
+                if (SettingsService.Instance.UseAccentColor)
+                {
+                    targetColor = (Windows.UI.Color)Application.Current.Resources["SystemAccentColor"];
+                }
+                else
+                {
+                    targetColor = SettingsService.Instance.CustomTintColor;
+                }
+
+                _acrylicController.TintColor = targetColor;
+                _acrylicController.TintOpacity = SettingsService.Instance.TintOpacity;
+                _acrylicController.LuminosityOpacity = SettingsService.Instance.LuminosityOpacity;
+            }
+        }
+
+        private void UpdateSolidBackground()
+        {
+            if (_isClosed) return;
+
+            // we intervene only, if "solid" is selected
+            if (SettingsService.Instance.BackdropType == "None")
+            {
+                Windows.UI.Color targetColor = SettingsService.Instance.UseAccentColor
+                    ? (Windows.UI.Color)Application.Current.Resources["SystemAccentColor"]
+                    : SettingsService.Instance.CustomTintColor;
+
+                RootGrid.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(targetColor);
+            }
+        }
+
+        // re-reads the live SystemAccentColor into the acrylic tint and the solid background, for a pure OS accent
+        // change; both already resolve the accent fresh on every call, so no window rebuild is needed
+        public void RefreshAccentSurfaces()
+        {
+            UpdateAcrylicProperties();
+            UpdateSolidBackground();
+        }
+
+        // dynamically applies the chosen backdrop material based on the users selection in the settings page
+        // setup follows the official Microsoft guide for system backdrops in XAML apps:
+        // https://learn.microsoft.com/en-us/windows/apps/develop/ui/system-backdrops
+        public void SetBackdrop(string backdropType)
+        {
+            if (_isClosed) return;
+
+            DispatcherQueue.EnsureSystemDispatcherQueue();
+
+            if (_configurationSource == null)
+            {
+                _configurationSource = new SystemBackdropConfiguration();
+                this.Activated += Window_Activated;
+                ((FrameworkElement)this.Content).ActualThemeChanged += Window_ThemeChanged;
+
+                _configurationSource.IsInputActive = true;
+                SetConfigurationSourceTheme();
+            }
+
+            // clean up any existing active controllers before applying a new one
+            _acrylicController?.Dispose();
+            _acrylicController = null;
+            _micaController?.Dispose();
+            _micaController = null;
+
+            if (backdropType == "Acrylic" && DesktopAcrylicController.IsSupported())
+            {
+                _acrylicController = new DesktopAcrylicController();
+                _acrylicController.AddSystemBackdropTarget(this.As<ICompositionSupportsSystemBackdrop>());
+                _acrylicController.SetSystemBackdropConfiguration(_configurationSource);
+
+                UpdateAcrylicProperties();
+
+                RootGrid.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            }
+            else if (backdropType == "Mica" && MicaController.IsSupported())
+            {
+                _micaController = new MicaController();
+                _micaController.AddSystemBackdropTarget(this.As<ICompositionSupportsSystemBackdrop>());
+                _micaController.SetSystemBackdropConfiguration(_configurationSource);
+
+                RootGrid.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.Transparent);
+            }
+            else
+            {
+                UpdateSolidBackground();
+            }
+        }
+
+        private void Window_ThemeChanged(FrameworkElement sender, object args)
+        {
+            SetConfigurationSourceTheme();
+        }
+
+        private void SetConfigurationSourceTheme()
+        {
+            if (_configurationSource != null && this.Content is FrameworkElement frameworkElement)
+            {
+                _configurationSource.Theme = frameworkElement.ActualTheme switch
+                {
+                    ElementTheme.Dark => SystemBackdropTheme.Dark,
+                    ElementTheme.Light => SystemBackdropTheme.Light,
+                    _ => SystemBackdropTheme.Default
+                };
+            }
+        }
+
+        // --- workaround: DWM backdrop swapchain kick ---
+        // problem: when Windows transparency/theme changes, WinUI 3 DesktopAcrylicController needs a backdrop re-bind
+        // to attach its blur shader to the newly created DWM swapchain
+        // fix: after window recreation, briefly kick the backdrop pipeline (None -> Mica/Acrylic) to force a DWM
+        // compositor refresh
+        private void KickBackdropRefresh()
+        {
+            if (_isClosed) return;
+
+            string currentBackdrop = SettingsService.Instance.BackdropType;
+            if (currentBackdrop == "Mica" || currentBackdrop == "Acrylic")
+            {
+                var timer = this.DispatcherQueue.CreateTimer();
+                timer.Interval = TimeSpan.FromMilliseconds(80);
+                timer.IsRepeating = false;
+                timer.Tick += (s, e) =>
+                {
+                    if (_isClosed) return;
+                    SetBackdrop("None");
+                    SetBackdrop(currentBackdrop);
+                };
+                timer.Start();
+            }
+        }
+    }
+}

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
@@ -36,9 +36,10 @@ namespace FluentSensors.Features.CsvLogging
         private AppWindow _appWindow;
         private const string WindowKey = "CsvLogger";
 
-        // fixed window width in XAML DIP; the height is always measured from the content instead, so collapsing the
+        // fixed window width in XAML DIP; the height is read back off the arranged rows instead, so collapsing the
         // lower region, hiding the status line, or a wrap panel that breaks into another row all resize correctly
         // without a second hand-tuned number
+        // the fallback only ever covers a measure that comes back empty, before the content exists at all
         private const double WindowWidthDip = 240;
         private const double FallbackWindowHeightDip = 232;
 
@@ -48,6 +49,10 @@ namespace FluentSensors.Features.CsvLogging
         // whether the lower region (readout and save location) is currently shown; pure view state, the recording
         // itself does not care
         private bool _isExpanded = true;
+
+        // guards ApplyWindowSize against re-entering itself: it resizes the window, that re-lays out both regions,
+        // and that is exactly what raises the SizeChanged which calls it
+        private bool _isApplyingSize;
 
         public CsvLoggerViewModel ViewModel { get; }
         public static CsvLoggerWindow CurrentInstance { get; private set; }
@@ -87,6 +92,11 @@ namespace FluentSensors.Features.CsvLogging
             // content state has to be applied before the first measure, both the status line and the expand state
             // change how tall the window ends up
             StatusTextBlock.Visibility = ShowStatusLine ? Visibility.Visible : Visibility.Collapsed;
+
+            // a StackPanel reserves its Spacing for a collapsed child as well, so dropping the status line has to
+            // drop the gap with it, otherwise a dead strip stays behind above the divider
+            UpperRegion.Spacing = ShowStatusLine ? UpperRegion.Spacing : 0;
+
             ApplyExpandState();
 
             // window size and position:
@@ -116,9 +126,11 @@ namespace FluentSensors.Features.CsvLogging
             }
             catch { }
 
-            // the status line is the one piece of content whose height is not fixed, a long file name wraps it onto
-            // another line; re-measuring on every change keeps the window exactly as tall as it needs to be
-            ViewModel.PropertyChanged += OnViewModelPropertyChanged;
+            // both regions sit in Auto rows, so their height is driven by their content and never by how tall the
+            // window is; re-applying the size whenever one of them changes is what keeps the window exactly as tall
+            // as what is in it, a status line that wraps onto a second row included
+            UpperRegion.SizeChanged += OnRegionSizeChanged;
+            LowerRegion.SizeChanged += OnRegionSizeChanged;
 
             this.Closed += CsvLoggerWindow_Closed;
             _appWindow.Changed += AppWindow_Changed;
@@ -214,7 +226,8 @@ namespace FluentSensors.Features.CsvLogging
             {
                 _appWindow.Closing -= AppWindow_Closing;
                 _appWindow.Changed -= AppWindow_Changed;
-                ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+                UpperRegion.SizeChanged -= OnRegionSizeChanged;
+                LowerRegion.SizeChanged -= OnRegionSizeChanged;
             }
             catch { }
 
@@ -298,7 +311,8 @@ namespace FluentSensors.Features.CsvLogging
             SettingsService.Instance.TintColorChanged -= OnTintColorChanged;
             SettingsService.Instance.ThemeChanged -= OnThemeChanged;
 
-            ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            UpperRegion.SizeChanged -= OnRegionSizeChanged;
+            LowerRegion.SizeChanged -= OnRegionSizeChanged;
             ViewModel.Cleanup();
 
             _acrylicController?.Dispose();
@@ -347,9 +361,8 @@ namespace FluentSensors.Features.CsvLogging
             ViewModel.SetReadoutActive(false);
         }
 
-        private void OnViewModelPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void OnRegionSizeChanged(object sender, SizeChangedEventArgs e)
         {
-            if (e.PropertyName != nameof(CsvLoggerViewModel.StatusText)) return;
             if (_isClosed) return;
 
             ApplyWindowSize();
@@ -491,24 +504,86 @@ namespace FluentSensors.Features.CsvLogging
             ToolTipService.SetToolTip(ToggleDetailsButton, _isExpanded ? "Hide details" : "Show details");
         }
 
-        // measures the content at the fixed window width and sizes the window to exactly that
-        // ResizeClient rather than Resize: with ExtendsContentIntoTitleBar the client area is the whole content, so
-        // this needs no assumption about how thick the window frame currently is
-        private void ApplyWindowSize()
+        // the exact height of one row, taken from the element itself rather than from a number kept in here, so it
+        // is always whatever the xaml currently says
+        // ActualHeight leaves the margin out while the row in RootGrid reserves it, so it has to be added back
+        private static double RowHeightDip(FrameworkElement row)
         {
-            double scaleFactor = GetScaleFactor();
+            if (row.Visibility != Visibility.Visible) return 0;
 
+            return row.ActualHeight + row.Margin.Top + row.Margin.Bottom;
+        }
+
+        // the height the content really needs
+        //
+        // summed from the four arranged rows rather than taken from a standalone RootGrid.Measure: a measure run
+        // outside a layout pass reports what the content would like at an unconstrained height, and for the wrapping
+        // readout and the wrapping status line that comes out taller than what ends up being arranged
+        private double ContentHeightDip()
+        {
+            // --- workaround: CommunityToolkit WrapPanel throws when measured at zero width ---
+            // problem: WrapPanel.MeasureOverride subtracts its Padding from the available size without clamping, so
+            // a measure at width 0 builds a Windows.Foundation.Size with a negative width and throws
+            // ArgumentOutOfRangeException, taking the app down with it
+            // that width is exactly what the xaml island reports while the window has not been shown yet, which is
+            // where the constructor calls this from
+            // fix: force the layout pass only once the content actually has a width, and estimate from a plain
+            // measure at the target width until then
+            if (RootGrid.ActualWidth > 0)
+            {
+                // synchronous, so the rows below report the state after a collapse or a status line change rather
+                // than the one before it
+                RootGrid.UpdateLayout();
+
+                double arranged = RowHeightDip(CustomTitleBar) + RowHeightDip(UpperRegion) +
+                                  RowHeightDip(Divider) + RowHeightDip(LowerRegion);
+                if (arranged > 0) return arranged;
+            }
+
+            // pre-layout estimate; a little generous for content that wraps, but it only ever sizes the window for
+            // the moment before it is shown, and the first real layout pass corrects it through SizeChanged
             RootGrid.InvalidateMeasure();
             RootGrid.Measure(new Windows.Foundation.Size(WindowWidthDip, double.PositiveInfinity));
 
-            // a measure before the content is ready can come back empty; the fallback keeps a usable window instead
-            // of a zero-height one
-            double heightDip = RootGrid.DesiredSize.Height;
-            if (heightDip <= 0) heightDip = FallbackWindowHeightDip;
+            double measured = RootGrid.DesiredSize.Height;
+            return measured > 0 ? measured : FallbackWindowHeightDip;
+        }
 
-            _appWindow.ResizeClient(new Windows.Graphics.SizeInt32(
-                (int)(WindowWidthDip * scaleFactor),
-                (int)(heightDip * scaleFactor)));
+        // sizes the window to exactly the content it has
+        private void ApplyWindowSize()
+        {
+            if (_isApplyingSize) return;
+            _isApplyingSize = true;
+
+            try
+            {
+                double scaleFactor = GetScaleFactor();
+
+                // how much bigger the window is than its client area, read off the window rather than assumed:
+                // ExtendsContentIntoTitleBar pulls the caption into the client area, so the caption height must not
+                // be added on top of the content the way a plain frame calculation would
+                int frameWidthPx = Math.Max(0, _appWindow.Size.Width - _appWindow.ClientSize.Width);
+                int frameHeightPx = Math.Max(0, _appWindow.Size.Height - _appWindow.ClientSize.Height);
+                int widthPx = (int)Math.Round(WindowWidthDip * scaleFactor) + frameWidthPx;
+
+                // the width has to be in place before the height is read; the readout wraps onto a second row at
+                // narrow widths, so reading the height at the old window width would report one the window never
+                // ends up having
+                if (_appWindow.Size.Width != widthPx)
+                {
+                    _appWindow.Resize(new Windows.Graphics.SizeInt32(widthPx, _appWindow.Size.Height));
+                }
+
+                double heightDip = ContentHeightDip();
+
+                _appWindow.Resize(new Windows.Graphics.SizeInt32(
+                    widthPx,
+                    (int)Math.Round(heightDip * scaleFactor) + frameHeightPx));
+            }
+            finally
+            {
+                _isApplyingSize = false;
+            }
         }
 
         private void RestoreWindowPosition()

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
@@ -409,6 +409,11 @@ namespace FluentSensors.Features.CsvLogging
             ViewModel.Stop();
         }
 
+        private void TogglePause_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.TogglePause();
+        }
+
         // collapses the window down to the divider, so a running recording can sit on screen as a thin bar with just
         // the stop button on it
         private void ToggleDetails_Click(object sender, RoutedEventArgs e)

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
@@ -44,7 +44,7 @@ namespace FluentSensors.Features.CsvLogging
         // lower region, hiding the status line, or a wrap panel that breaks into another row all resize correctly
         // without a second hand-tuned number
         // the fallback only ever covers a measure that comes back empty, before the content exists at all
-        private const double WindowWidthDip = 220;
+        private const double WindowWidthDip = 235;
         private const double FallbackWindowHeightDip = 232;
 
         // status line under main bar

--- a/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 
+using FluentSensors.Common.Csv;
 using FluentSensors.Common.Sensors;
 using FluentSensors.Controls.SensorRow;
 using FluentSensors.Core;
@@ -45,6 +46,11 @@ namespace FluentSensors.Features.CsvLogging
         // the column set the open file was started with, snapshotted so the monitor thread never reads _sensors
         // while the sensors page is replacing it
         private CsvLoggedSensor[] _activeColumns;
+
+        // separators the open file was started with, snapshotted the same way _activeColumns is: a format switch
+        // midway through a recording would leave one half of the file unreadable
+        private string _separator = ",";
+        private CultureInfo _valueCulture = CultureInfo.InvariantCulture;
 
         private StreamWriter _writer;
         private DateTime _startedAt;
@@ -134,6 +140,7 @@ namespace FluentSensors.Features.CsvLogging
         {
             if (IsRunning || _sensors.Count == 0) return false;
 
+            var (separator, valueCulture) = ResolveFormat(SettingsService.Instance.CsvNumberFormat);
             string folder = ResolvedLogFolder;
             string path = Path.Combine(folder, $"FluentSensors-Log-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv");
             var columns = _sensors.ToArray();
@@ -147,7 +154,7 @@ namespace FluentSensors.Features.CsvLogging
                 // AutoFlush is not optional: the tray Exit and the settings restart both end in Process.Kill(),
                 // which skips finalizers and every closing handler, so a buffered tail would be lost without a trace
                 _writer = new StreamWriter(path, false, new UTF8Encoding(true)) { AutoFlush = true };
-                _writer.WriteLine(BuildHeaderLine(columns));
+                _writer.WriteLine(BuildHeaderLine(columns, separator));
             }
             catch
             {
@@ -164,6 +171,8 @@ namespace FluentSensors.Features.CsvLogging
             }
 
             LastError = null;
+            _separator = separator;
+            _valueCulture = valueCulture;
             _activeColumns = columns;
             CurrentFilePath = path;
             Interlocked.Exchange(ref _rowCount, 0);
@@ -216,18 +225,29 @@ namespace FluentSensors.Features.CsvLogging
             var columns = _activeColumns;
             if (columns == null) return;
 
+            string separator = _separator;
+            var valueCulture = _valueCulture;
+
             var values = new Dictionary<string, double>(payload.Count);
             foreach (var sensor in payload)
             {
                 values[sensor.Id] = sensor.Value;
             }
 
+            // one instant for both time columns, so the wall clock and the elapsed seconds can never disagree by the
+            // few microseconds two separate reads would drift apart
+            DateTime nowUtc = DateTime.UtcNow;
+
             var line = new StringBuilder();
-            line.Append(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture));
+            // the timestamp stays invariant in both formats; its separators are the ISO ones, and running them
+            // through a culture would swap the date and time separators for no gain
+            line.Append(nowUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture));
+            line.Append(separator);
+            line.Append((nowUtc - _startedAt).TotalSeconds.ToString("0.000", valueCulture));
 
             foreach (var column in columns)
             {
-                line.Append(',');
+                line.Append(separator);
 
                 // a sensor missing from this payload (hidden after the recording started, or hardware gone) leaves
                 // the field empty; a zero would read as a real measurement
@@ -235,7 +255,7 @@ namespace FluentSensors.Features.CsvLogging
                 {
                     // the raw value, never the SensorUnitFormatter scaling: that switches MHz to GHz above 1000 and
                     // would change a columns unit halfway through the file
-                    line.Append(value.ToString("0.###", CultureInfo.InvariantCulture));
+                    line.Append(value.ToString("0.###", valueCulture));
                 }
             }
 
@@ -287,23 +307,46 @@ namespace FluentSensors.Features.CsvLogging
             return unit.Length > 0 ? $"{name} [{unit}]" : name;
         }
 
-        private static string BuildHeaderLine(CsvLoggedSensor[] columns)
+        // resolves the configured format into the two things a row actually needs
+        // Local reads the machines own regional settings rather than hardcoding german, so the file matches
+        // whatever spreadsheet app is installed on the system that wrote it
+        // (public so the settings page can label its entries with the row this actually writes)
+        public static (string separator, CultureInfo valueCulture) ResolveFormat(CsvNumberFormat format)
         {
-            var line = new StringBuilder("Timestamp");
+            if (format == CsvNumberFormat.Invariant)
+            {
+                return (",", CultureInfo.InvariantCulture);
+            }
+
+            var culture = CultureInfo.CurrentCulture;
+            string separator = culture.TextInfo.ListSeparator;
+
+            // a locale whose list separator is also its decimal separator would write rows nothing can read back;
+            // the semicolon is what every spreadsheet falls back to in that case
+            if (separator == culture.NumberFormat.NumberDecimalSeparator) separator = ";";
+
+            return (separator, culture);
+        }
+
+        private static string BuildHeaderLine(CsvLoggedSensor[] columns, string separator)
+        {
+            // the elapsed column sits next to the wall clock deliberately: it is what makes two recordings comparable
+            // on one axis without subtracting timestamps first
+            var line = new StringBuilder("Timestamp").Append(separator).Append("Elapsed [s]");
 
             foreach (var column in columns)
             {
-                line.Append(',').Append(EscapeCsvField(column.Header));
+                line.Append(separator).Append(EscapeCsvField(column.Header, separator));
             }
 
             return line.ToString();
         }
 
-        // header text only; hardware names can carry a comma ("AMD Ryzen 7 5800X, 8-Core"), the numeric fields never
-        // need this
-        private static string EscapeCsvField(string field)
+        // header text only; hardware names can carry the separator ("AMD Ryzen 7 5800X, 8-Core"), the numeric
+        // fields never can, their decimal separator is never the field one
+        private static string EscapeCsvField(string field, string separator)
         {
-            if (field.IndexOf(',') < 0 && field.IndexOf('"') < 0) return field;
+            if (!field.Contains(separator) && field.IndexOf('"') < 0) return field;
 
             return $"\"{field.Replace("\"", "\"\"")}\"";
         }

--- a/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
@@ -238,6 +238,30 @@ namespace FluentSensors.Features.CsvLogging
             StateChanged?.Invoke();
         }
 
+        // clears what a finished recording left behind, so the readout comes back up empty instead of showing the
+        // counters of a session that is long over
+        //
+        // has to be explicit because CsvLoggerWindow is only hidden when it is closed and reused afterwards; the
+        // sensor selection is deliberately kept, it comes from the sensors page and is what makes the next start
+        // possible at all
+        //
+        // a running recording is never touched: closing the readout stops the readout, never the logging
+        public void ResetCompletedRecording()
+        {
+            if (IsRunning) return;
+
+            _startedAt = default;
+            _stoppedAt = default;
+            _pausedTotal = TimeSpan.Zero;
+            _pauseCount = 0;
+            Interlocked.Exchange(ref _rowCount, 0);
+
+            CurrentFilePath = null;
+            LastError = null;
+
+            StateChanged?.Invoke();
+        }
+
         // holds the recording without giving up the file: the columns, the header and the row counter all stay,
         // only the incoming payloads are dropped
         public void Pause()
@@ -333,10 +357,10 @@ namespace FluentSensors.Features.CsvLogging
             line.Append(nowUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture));
             line.Append(separator);
 
-            // the elapsed column keeps its own fixed three decimals and ignores the configured value precision:
-            // its resolution belongs to the poll interval, and rounded to whole seconds it would be useless at the
-            // 500 ms the monitor runs at by default
-            line.Append((nowUtc - _startedAt).TotalSeconds.ToString("0.000", rowFormat.ValueCulture));
+            // the elapsed column keeps its own fixed single decimal and ignores the configured value precision:
+            // its resolution belongs to the poll interval, not to how precisely a sensor is worth reading, and a
+            // tenth of a second is already finer than the 500 ms the monitor runs at by default
+            line.Append((nowUtc - _startedAt).TotalSeconds.ToString("0.0", rowFormat.ValueCulture));
 
             foreach (var column in columns)
             {

--- a/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+using FluentSensors.Common.Sensors;
+using FluentSensors.Controls.SensorRow;
+using FluentSensors.Core;
+using FluentSensors.Features.Sensors;
+using FluentSensors.Persistence.Services;
+
+
+namespace FluentSensors.Features.CsvLogging
+{
+    // one column of a recording: the sensor id every payload is matched against, plus the header text written once
+    // into the first line of the file
+    public class CsvLoggedSensor
+    {
+        public CsvLoggedSensor(string id, string header)
+        {
+            Id = id;
+            Header = header;
+        }
+
+        public string Id { get; }
+        public string Header { get; }
+    }
+
+
+    // owns a running csv recording: the column set, the open file, the row counter and the elapsed clock
+    //
+    // deliberately a service and not window state; CsvLoggerWindow only hides itself when closed (the WinUI
+    // retained-instance pattern) and gets fully rebuilt when Windows theme or transparency changes, and a recording
+    // has to survive both without dropping a single row
+    public class CsvLoggingService
+    {
+        // === fields ===
+
+        private readonly List<CsvLoggedSensor> _sensors = new();
+        private readonly object _writeLock = new();
+
+        // the column set the open file was started with, snapshotted so the monitor thread never reads _sensors
+        // while the sensors page is replacing it
+        private CsvLoggedSensor[] _activeColumns;
+
+        private StreamWriter _writer;
+        private DateTime _startedAt;
+        private DateTime _stoppedAt;
+        private long _rowCount;
+
+
+        // === singleton instance ===
+
+        public static CsvLoggingService Instance { get; } = new CsvLoggingService();
+
+
+        // === constructor ===
+
+        private CsvLoggingService() { }
+
+
+        // === bindable state ===
+
+        public bool IsRunning { get; private set; }
+        public string CurrentFilePath { get; private set; }
+        public int SensorCount => _sensors.Count;
+        public long RowCount => Interlocked.Read(ref _rowCount);
+
+        // set when a start attempt could not open its file, cleared by the next successful start; the logger window
+        // is the only place this surfaces
+        public string LastError { get; private set; }
+
+        // where recordings are written; the settings value while one has been picked, otherwise a subfolder in
+        // Documents so the logs land somewhere the user can actually find them
+        public string ResolvedLogFolder
+        {
+            get
+            {
+                string configured = SettingsService.Instance.CsvLogFolder;
+                if (!string.IsNullOrEmpty(configured)) return configured;
+
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "FluentSensors");
+            }
+        }
+
+        // keeps counting while recording, then freezes on the final duration, so the readout still shows how long
+        // the finished recording ran
+        public TimeSpan Elapsed
+        {
+            get
+            {
+                if (_startedAt == default) return TimeSpan.Zero;
+                return (IsRunning ? DateTime.UtcNow : _stoppedAt) - _startedAt;
+            }
+        }
+
+        // fires on start, stop and on a taken-over selection; always from the UI thread since every caller is a
+        // click handler;
+        // The row counter deliberately has no event of its own, CsvLoggerViewModel polls it on a timer instead so
+        // the recording never touches the UI thread at all
+        public event Action StateChanged;
+
+
+        // === public api ===
+
+        // takes over the sensor selection pushed from the sensors page
+        // Ignored while a recording runs: the column set is written into the file header once at start, changing it
+        // afterwards would silently invalidate every row before it
+        public void SetSensors(List<SensorRowViewModel> selectedSensors)
+        {
+            if (IsRunning) return;
+
+            var hardwareNames = BuildHardwareNameMap();
+
+            _sensors.Clear();
+            foreach (var sensor in selectedSensors)
+            {
+                _sensors.Add(new CsvLoggedSensor(sensor.Id, BuildHeader(sensor, hardwareNames)));
+            }
+
+            StateChanged?.Invoke();
+        }
+
+        // opens a fresh csv file in the configured folder and starts recording; returns false when there is nothing
+        // to record or the file could not be opened
+        //
+        // deliberately asks nothing: the folder is picked up front from the logger window, so pressing start is a
+        // single click even for a long series of recordings, and the file name is always a fresh timestamp so no
+        // earlier recording can be overwritten
+        public bool Start()
+        {
+            if (IsRunning || _sensors.Count == 0) return false;
+
+            string folder = ResolvedLogFolder;
+            string path = Path.Combine(folder, $"FluentSensors-Log-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv");
+            var columns = _sensors.ToArray();
+
+            try
+            {
+                Directory.CreateDirectory(folder);
+
+                // utf-8 with BOM so a double click in Excel picks up the encoding on its own and unit symbols like
+                // the degree sign survive
+                // AutoFlush is not optional: the tray Exit and the settings restart both end in Process.Kill(),
+                // which skips finalizers and every closing handler, so a buffered tail would be lost without a trace
+                _writer = new StreamWriter(path, false, new UTF8Encoding(true)) { AutoFlush = true };
+                _writer.WriteLine(BuildHeaderLine(columns));
+            }
+            catch
+            {
+                // a folder we cannot write to (protected location, drive gone, file open elsewhere) leaves the
+                // recording unstarted;
+                // The reason is named rather than swallowed, this is the one failure the user
+                // can actually fix
+                try { _writer?.Dispose(); } catch { }
+                _writer = null;
+
+                LastError = $"could not write to {folder}";
+                StateChanged?.Invoke();
+                return false;
+            }
+
+            LastError = null;
+            _activeColumns = columns;
+            CurrentFilePath = path;
+            Interlocked.Exchange(ref _rowCount, 0);
+            _startedAt = DateTime.UtcNow;
+            _stoppedAt = _startedAt;
+            IsRunning = true;
+
+            HardwareMonitorService.Instance.HardwareDataUpdated += OnHardwareDataUpdated;
+            StateChanged?.Invoke();
+            return true;
+        }
+
+        // drops a previous start failure, called after the user picked a different folder so the old message does
+        // not keep pointing at a location that is no longer the target
+        public void ClearLastError()
+        {
+            if (LastError == null) return;
+
+            LastError = null;
+            StateChanged?.Invoke();
+        }
+
+        public void Stop()
+        {
+            if (!IsRunning) return;
+
+            HardwareMonitorService.Instance.HardwareDataUpdated -= OnHardwareDataUpdated;
+            _stoppedAt = DateTime.UtcNow;
+            IsRunning = false;
+
+            // a payload that arrived just before the unsubscribe can still be inside the write below, so closing the
+            // file takes the same lock the rows do
+            lock (_writeLock)
+            {
+                try { _writer?.Dispose(); } catch { /* every row is already flushed, a failing dispose loses nothing */ }
+                _writer = null;
+                _activeColumns = null;
+            }
+
+            StateChanged?.Invoke();
+        }
+
+
+        // === recording ===
+
+        // runs on the HardwareMonitorService background thread and deliberately stays there; writing a row is pure
+        // file I/O and touches nothing bindable, so there is no reason to pay a dispatcher hop per poll
+        private void OnHardwareDataUpdated(List<SensorData> payload)
+        {
+            var columns = _activeColumns;
+            if (columns == null) return;
+
+            var values = new Dictionary<string, double>(payload.Count);
+            foreach (var sensor in payload)
+            {
+                values[sensor.Id] = sensor.Value;
+            }
+
+            var line = new StringBuilder();
+            line.Append(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture));
+
+            foreach (var column in columns)
+            {
+                line.Append(',');
+
+                // a sensor missing from this payload (hidden after the recording started, or hardware gone) leaves
+                // the field empty; a zero would read as a real measurement
+                if (values.TryGetValue(column.Id, out double value))
+                {
+                    // the raw value, never the SensorUnitFormatter scaling: that switches MHz to GHz above 1000 and
+                    // would change a columns unit halfway through the file
+                    line.Append(value.ToString("0.###", CultureInfo.InvariantCulture));
+                }
+            }
+
+            lock (_writeLock)
+            {
+                if (_writer == null) return;
+
+                try
+                {
+                    _writer.WriteLine(line.ToString());
+                }
+                catch
+                {
+                    // best-effort; a disk that stopped accepting writes must not tear down the monitoring loop
+                    return;
+                }
+            }
+
+            Interlocked.Increment(ref _rowCount);
+        }
+
+
+        // === private helpers ===
+
+        // maps every known sensor id to the hardware it sits on, so two identically named sensors on different
+        // hardware ("Temperature" on the CPU and on the GPU) never collapse into the same column title
+        private static Dictionary<string, string> BuildHardwareNameMap()
+        {
+            var map = new Dictionary<string, string>();
+
+            foreach (var group in SensorsViewModel.Instance.HardwareGroups)
+            {
+                foreach (var sensor in group.Sensors.Concat(group.HiddenSensors))
+                {
+                    map[sensor.Id] = group.HardwareName;
+                }
+            }
+
+            return map;
+        }
+
+        private static string BuildHeader(SensorRowViewModel sensor, Dictionary<string, string> hardwareNames)
+        {
+            string unit = SensorUnitFormatter.GetUnit(sensor.SensorType);
+            string name = hardwareNames.TryGetValue(sensor.Id, out string hardwareName) && !string.IsNullOrEmpty(hardwareName)
+                ? $"{hardwareName} {sensor.Name}"
+                : sensor.Name;
+
+            return unit.Length > 0 ? $"{name} [{unit}]" : name;
+        }
+
+        private static string BuildHeaderLine(CsvLoggedSensor[] columns)
+        {
+            var line = new StringBuilder("Timestamp");
+
+            foreach (var column in columns)
+            {
+                line.Append(',').Append(EscapeCsvField(column.Header));
+            }
+
+            return line.ToString();
+        }
+
+        // header text only; hardware names can carry a comma ("AMD Ryzen 7 5800X, 8-Core"), the numeric fields never
+        // need this
+        private static string EscapeCsvField(string field)
+        {
+            if (field.IndexOf(',') < 0 && field.IndexOf('"') < 0) return field;
+
+            return $"\"{field.Replace("\"", "\"\"")}\"";
+        }
+    }
+}

--- a/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
@@ -20,14 +20,18 @@ namespace FluentSensors.Features.CsvLogging
     // into the first line of the file
     public class CsvLoggedSensor
     {
-        public CsvLoggedSensor(string id, string header)
+        public CsvLoggedSensor(string id, string header, string unit)
         {
             Id = id;
             Header = header;
+            Unit = unit;
         }
 
         public string Id { get; }
         public string Header { get; }
+
+        // written next to every value while that option is on; empty for sensor types that carry no unit
+        public string Unit { get; }
     }
 
 
@@ -47,10 +51,21 @@ namespace FluentSensors.Features.CsvLogging
         // while the sensors page is replacing it
         private CsvLoggedSensor[] _activeColumns;
 
-        // separators the open file was started with, snapshotted the same way _activeColumns is: a format switch
-        // midway through a recording would leave one half of the file unreadable
-        private string _separator = ",";
-        private CultureInfo _valueCulture = CultureInfo.InvariantCulture;
+        // the format the open file was started with, snapshotted the same way _activeColumns is: a switch of the
+        // separators, the decimal count or the units midway through a recording would leave one half of the file
+        // formatted differently from the other, and nothing reading it would notice
+        private CsvRowFormat _rowFormat;
+
+        // how much of Elapsed was spent holding, and how often; both reset with every fresh start
+        private TimeSpan _pausedTotal;
+        private DateTime _pauseStartedAt;
+        private int _pauseCount;
+
+        // set by Pause, cleared by Resume; the file and the column set stay open the whole time, only the rows
+        // stop arriving
+        // volatile because the click that sets it and the monitor thread that reads it never share a lock, and a
+        // resume that the writer only notices two polls later would drop measurements for no reason
+        private volatile bool _isPaused;
 
         private StreamWriter _writer;
         private DateTime _startedAt;
@@ -71,6 +86,10 @@ namespace FluentSensors.Features.CsvLogging
         // === bindable state ===
 
         public bool IsRunning { get; private set; }
+
+        // true only while a recording is open and holding; IsRunning stays true through a pause, so the elapsed
+        // clock keeps counting and the file stays claimed
+        public bool IsPaused { get; private set; }
         public string CurrentFilePath { get; private set; }
         public int SensorCount => _sensors.Count;
         public long RowCount => Interlocked.Read(ref _rowCount);
@@ -103,6 +122,26 @@ namespace FluentSensors.Features.CsvLogging
             }
         }
 
+        // the stretch that is actually covered by rows, so the main bar readout can never contradict the row
+        // counter sitting next to it: at a 500 ms poll, 1200 rows are ten minutes, and after a pause the wall
+        // clock would claim thirteen
+        // the running pause is subtracted on the fly, so the number freezes the instant the button is hit
+        public TimeSpan RecordedElapsed
+        {
+            get
+            {
+                var paused = _pausedTotal;
+                if (_isPaused) paused += DateTime.UtcNow - _pauseStartedAt;
+
+                var recorded = Elapsed - paused;
+                return recorded > TimeSpan.Zero ? recorded : TimeSpan.Zero;
+            }
+        }
+
+        // what explains the gap between Elapsed and RecordedElapsed, and at the same time how many seam rows the
+        // file carries
+        public int PauseCount => _pauseCount;
+
         // fires on start, stop and on a taken-over selection; always from the UI thread since every caller is a
         // click handler;
         // The row counter deliberately has no event of its own, CsvLoggerViewModel polls it on a timer instead so
@@ -124,7 +163,8 @@ namespace FluentSensors.Features.CsvLogging
             _sensors.Clear();
             foreach (var sensor in selectedSensors)
             {
-                _sensors.Add(new CsvLoggedSensor(sensor.Id, BuildHeader(sensor, hardwareNames)));
+                _sensors.Add(new CsvLoggedSensor(sensor.Id, BuildHeader(sensor, hardwareNames),
+                    SensorUnitFormatter.GetUnit(sensor.SensorType)));
             }
 
             StateChanged?.Invoke();
@@ -140,7 +180,7 @@ namespace FluentSensors.Features.CsvLogging
         {
             if (IsRunning || _sensors.Count == 0) return false;
 
-            var (separator, valueCulture) = ResolveFormat(SettingsService.Instance.CsvNumberFormat);
+            var rowFormat = CsvRowFormat.Resolve();
             string folder = ResolvedLogFolder;
             string path = Path.Combine(folder, $"FluentSensors-Log-{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.csv");
             var columns = _sensors.ToArray();
@@ -154,7 +194,7 @@ namespace FluentSensors.Features.CsvLogging
                 // AutoFlush is not optional: the tray Exit and the settings restart both end in Process.Kill(),
                 // which skips finalizers and every closing handler, so a buffered tail would be lost without a trace
                 _writer = new StreamWriter(path, false, new UTF8Encoding(true)) { AutoFlush = true };
-                _writer.WriteLine(BuildHeaderLine(columns, separator));
+                _writer.WriteLine(BuildHeaderLine(columns, rowFormat.Separator));
             }
             catch
             {
@@ -171,8 +211,11 @@ namespace FluentSensors.Features.CsvLogging
             }
 
             LastError = null;
-            _separator = separator;
-            _valueCulture = valueCulture;
+            _rowFormat = rowFormat;
+            _pausedTotal = TimeSpan.Zero;
+            _pauseCount = 0;
+            _isPaused = false;
+            IsPaused = false;
             _activeColumns = columns;
             CurrentFilePath = path;
             Interlocked.Exchange(ref _rowCount, 0);
@@ -195,6 +238,38 @@ namespace FluentSensors.Features.CsvLogging
             StateChanged?.Invoke();
         }
 
+        // holds the recording without giving up the file: the columns, the header and the row counter all stay,
+        // only the incoming payloads are dropped
+        public void Pause()
+        {
+            if (!IsRunning || _isPaused) return;
+
+            _pauseStartedAt = DateTime.UtcNow;
+            _pauseCount++;
+            _isPaused = true;
+            IsPaused = true;
+
+            StateChanged?.Invoke();
+        }
+
+        public void Resume()
+        {
+            if (!IsRunning || !_isPaused) return;
+
+            // the seam is written before the flag is cleared, so a payload arriving in between cannot slip a real
+            // measurement in front of the gap row
+            if (SettingsService.Instance.CsvPauseSeam == CsvPauseSeam.Gap)
+            {
+                WriteSeamRow();
+            }
+
+            _pausedTotal += DateTime.UtcNow - _pauseStartedAt;
+            _isPaused = false;
+            IsPaused = false;
+
+            StateChanged?.Invoke();
+        }
+
         public void Stop()
         {
             if (!IsRunning) return;
@@ -202,6 +277,15 @@ namespace FluentSensors.Features.CsvLogging
             HardwareMonitorService.Instance.HardwareDataUpdated -= OnHardwareDataUpdated;
             _stoppedAt = DateTime.UtcNow;
             IsRunning = false;
+
+            // a recording stopped while it was holding still has that last interval open; closing it against the
+            // stop instant is what keeps the final recorded duration correct
+            if (_isPaused)
+            {
+                _pausedTotal += _stoppedAt - _pauseStartedAt;
+                _isPaused = false;
+                IsPaused = false;
+            }
 
             // a payload that arrived just before the unsubscribe can still be inside the write below, so closing the
             // file takes the same lock the rows do
@@ -225,8 +309,13 @@ namespace FluentSensors.Features.CsvLogging
             var columns = _activeColumns;
             if (columns == null) return;
 
-            string separator = _separator;
-            var valueCulture = _valueCulture;
+            // a paused recording keeps its file open and simply lets the payload go by
+            if (_isPaused) return;
+
+            var rowFormat = _rowFormat;
+            if (rowFormat == null) return;
+
+            string separator = rowFormat.Separator;
 
             var values = new Dictionary<string, double>(payload.Count);
             foreach (var sensor in payload)
@@ -243,7 +332,11 @@ namespace FluentSensors.Features.CsvLogging
             // through a culture would swap the date and time separators for no gain
             line.Append(nowUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture));
             line.Append(separator);
-            line.Append((nowUtc - _startedAt).TotalSeconds.ToString("0.000", valueCulture));
+
+            // the elapsed column keeps its own fixed three decimals and ignores the configured value precision:
+            // its resolution belongs to the poll interval, and rounded to whole seconds it would be useless at the
+            // 500 ms the monitor runs at by default
+            line.Append((nowUtc - _startedAt).TotalSeconds.ToString("0.000", rowFormat.ValueCulture));
 
             foreach (var column in columns)
             {
@@ -255,7 +348,7 @@ namespace FluentSensors.Features.CsvLogging
                 {
                     // the raw value, never the SensorUnitFormatter scaling: that switches MHz to GHz above 1000 and
                     // would change a columns unit halfway through the file
-                    line.Append(value.ToString("0.###", valueCulture));
+                    line.Append(rowFormat.FormatValue(value, column.Unit));
                 }
             }
 
@@ -275,6 +368,38 @@ namespace FluentSensors.Features.CsvLogging
             }
 
             Interlocked.Increment(ref _rowCount);
+        }
+
+        // one row of empty fields at the point a pause was resumed, so a chart drawn from the file breaks its line
+        // there instead of interpolating across a stretch that was never measured
+        //
+        // deliberately not counted into _rowCount: it carries no measurement, and the readout would otherwise claim
+        // rows the recording never took
+        private void WriteSeamRow()
+        {
+            var columns = _activeColumns;
+            var rowFormat = _rowFormat;
+            if (columns == null || rowFormat == null) return;
+
+            // two fixed columns (timestamp and elapsed) plus one per sensor, so the seam keeps the column count of
+            // every other row and reads back as empty cells rather than as a short row
+            string line = new StringBuilder()
+                .Insert(0, rowFormat.Separator, columns.Length + 1)
+                .ToString();
+
+            lock (_writeLock)
+            {
+                if (_writer == null) return;
+
+                try
+                {
+                    _writer.WriteLine(line);
+                }
+                catch
+                {
+                    // same best-effort rule the rows follow
+                }
+            }
         }
 
 
@@ -305,27 +430,6 @@ namespace FluentSensors.Features.CsvLogging
                 : sensor.Name;
 
             return unit.Length > 0 ? $"{name} [{unit}]" : name;
-        }
-
-        // resolves the configured format into the two things a row actually needs
-        // Local reads the machines own regional settings rather than hardcoding german, so the file matches
-        // whatever spreadsheet app is installed on the system that wrote it
-        // (public so the settings page can label its entries with the row this actually writes)
-        public static (string separator, CultureInfo valueCulture) ResolveFormat(CsvNumberFormat format)
-        {
-            if (format == CsvNumberFormat.Invariant)
-            {
-                return (",", CultureInfo.InvariantCulture);
-            }
-
-            var culture = CultureInfo.CurrentCulture;
-            string separator = culture.TextInfo.ListSeparator;
-
-            // a locale whose list separator is also its decimal separator would write rows nothing can read back;
-            // the semicolon is what every spreadsheet falls back to in that case
-            if (separator == culture.NumberFormat.NumberDecimalSeparator) separator = ";";
-
-            return (separator, culture);
         }
 
         private static string BuildHeaderLine(CsvLoggedSensor[] columns, string separator)

--- a/FluentSensors/Features/Sensors/SensorsPage.xaml
+++ b/FluentSensors/Features/Sensors/SensorsPage.xaml
@@ -107,7 +107,7 @@
                                 Click="StartCsvMonitoring_Click"
                                 Label="Start CSV Logging">
                                 <AppBarButton.Icon>
-                                    <FontIcon Glyph="&#xED1A;" />
+                                    <FontIcon Glyph="&#xE8A7;" />
                                 </AppBarButton.Icon>
                             </AppBarButton>
 

--- a/FluentSensors/Features/Sensors/SensorsPage.xaml
+++ b/FluentSensors/Features/Sensors/SensorsPage.xaml
@@ -107,7 +107,7 @@
                                 Click="StartCsvMonitoring_Click"
                                 Label="Start CSV Logging">
                                 <AppBarButton.Icon>
-                                    <FontIcon Glyph="&#xE768;" />
+                                    <FontIcon Glyph="&#xED1A;" />
                                 </AppBarButton.Icon>
                             </AppBarButton>
 

--- a/FluentSensors/Features/Sensors/SensorsPage.xaml.cs
+++ b/FluentSensors/Features/Sensors/SensorsPage.xaml.cs
@@ -12,6 +12,7 @@ using Windows.Foundation;
 
 using FluentSensors.Features.Widget;
 using FluentSensors.Features.TaskbarWidget;
+using FluentSensors.Features.CsvLogging;
 using FluentSensors.Common.UI;
 using FluentSensors.Common.Sensors;
 
@@ -91,9 +92,39 @@ namespace FluentSensors.Features.Sensors
             WidgetWindow.ShowWithSensors(selectedSensors);
         }
 
-        // Phase 1: no csv consumer exists yet, theres no action to perform on the current selection
-        private void StartCsvMonitoring_Click(object sender, RoutedEventArgs e)
+        // opens or reconfigures the csv logger window with whatever is currently checked
+        // persistence already happened live as each checkbox was toggled, this button hands the selection to the
+        // logger and brings its window up
+        private async void StartCsvMonitoring_Click(object sender, RoutedEventArgs e)
         {
+            var selectedSensors = ViewModel.HardwareGroups
+                .SelectMany(group => group.Sensors)
+                .Where(sensor => sensor.IsSelected)
+                .ToList();
+
+            // an empty selection is only an error while nothing is being recorded; a running recording carries its
+            // own fixed sensor set, so the button just brings the logger back up in that case
+            if (selectedSensors.Count == 0 && !CsvLoggingService.Instance.IsRunning)
+            {
+                _infoBarTicket++;
+                int currentTicket = _infoBarTicket;
+
+                // show inforbar
+                AnimateInfoBar(-40, true);
+
+                await Task.Delay(2000);
+
+                if (currentTicket == _infoBarTicket)
+                {
+                    // hide infobar
+                    AnimateInfoBar(100, false);
+                }
+                return;
+            }
+
+            // reuses the existing logger window if one is open or was previously hidden, only creates a fresh native
+            // window if none exists yet at all (see CsvLoggerWindow._retainedInstance)
+            CsvLoggerWindow.ShowWithSensors(selectedSensors);
         }
 
         private async void PinToTaskbar_Click(object sender, RoutedEventArgs e)

--- a/FluentSensors/Features/Settings/SettingsPage.xaml
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml
@@ -350,21 +350,100 @@
                 Style="{StaticResource BodyStrongTextBlockStyle}"
                 Text="CSV Logging" />
 
-            <!--  separators a csv recording is written with  -->
-            <controls:SettingsCard
-                Description="Decimal and column separators a recording is written with"
+            <!--  everything that shapes a recorded row  -->
+            <!--
+                the format itself sits in the header slot, the way both background material expanders carry their
+                backdrop combo: it is the one choice that decides whether the file opens correctly at all, the three
+                inside are refinements
+            -->
+            <controls:SettingsExpander
+                Description="How values are written into a recording"
                 Header="CSV Format"
-                HeaderIcon="{toolkit:FontIcon Glyph=&#xE7C3;}">
+                HeaderIcon="{toolkit:FontIcon Glyph=&#xE7C3;}"
+                IsExpanded="False">
 
-                <!--  both entries are labelled from code with the sample row they actually produce  -->
                 <ComboBox
                     x:Name="CsvNumberFormatComboBox"
-                    Width="230"
+                    Width="160"
                     SelectionChanged="CsvNumberFormatComboBox_SelectionChanged">
-                    <ComboBoxItem Tag="Local" />
-                    <ComboBoxItem Tag="Invariant" />
+                    <ComboBoxItem Content="Regional" Tag="Local" />
+                    <ComboBoxItem Content="Invariant" Tag="Invariant" />
                 </ComboBox>
-            </controls:SettingsCard>
+
+                <!--
+                    the one element here that is not a setting, so it sits in the one slot that is not a
+                    settings row
+                -->
+                <!--
+                    (same top bar the sensors page puts above its sensor rows; text is built from code, through
+                    the same formatter that writes the file)
+                -->
+                <controls:SettingsExpander.ItemsHeader>
+                    <controls:SettingsCard
+                        MinHeight="0"
+                        Padding="58,12,16,8"
+                        HorizontalContentAlignment="Stretch"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderThickness="0"
+                        ContentAlignment="Vertical"
+                        CornerRadius="0">
+
+                        <Grid HorizontalAlignment="Stretch" ColumnSpacing="16">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock
+                                Grid.Column="0"
+                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                Style="{ThemeResource CaptionTextBlockStyle}"
+                                Text="Example row:" />
+
+                            <TextBlock
+                                x:Name="CsvFormatExampleTextBlock"
+                                Grid.Column="1"
+                                IsTextSelectionEnabled="True"
+                                Style="{ThemeResource CaptionTextBlockStyle}"
+                                TextWrapping="Wrap"
+                                Typography.NumeralAlignment="Tabular" />
+                        </Grid>
+                    </controls:SettingsCard>
+                </controls:SettingsExpander.ItemsHeader>
+
+                <controls:SettingsExpander.Items>
+                    <controls:SettingsCard Header="Decimal Places">
+                        <ComboBox
+                            x:Name="CsvDecimalPlacesComboBox"
+                            Width="70"
+                            SelectionChanged="CsvDecimalPlacesComboBox_SelectionChanged">
+                            <ComboBoxItem Content="0" Tag="0" />
+                            <ComboBoxItem Content="1" Tag="1" />
+                            <ComboBoxItem Content="2" Tag="2" />
+                            <ComboBoxItem Content="3" Tag="3" />
+                        </ComboBox>
+                    </controls:SettingsCard>
+
+                    <controls:SettingsCard Header="Units In Values">
+                        <ToggleSwitch
+                            x:Name="CsvIncludeUnitsToggle"
+                            OffContent="Off"
+                            OnContent="On"
+                            Toggled="CsvIncludeUnitsToggle_Toggled" />
+                    </controls:SettingsCard>
+
+                    <controls:SettingsCard Header="Pause Behavior">
+                        <ComboBox
+                            x:Name="CsvPauseSeamComboBox"
+                            Width="190"
+                            SelectionChanged="CsvPauseSeamComboBox_SelectionChanged">
+                            <ComboBoxItem Content="Leave an empty row" Tag="Gap" />
+                            <ComboBoxItem Content="Continue seamlessly" Tag="Seamless" />
+                        </ComboBox>
+                    </controls:SettingsCard>
+                </controls:SettingsExpander.Items>
+
+            </controls:SettingsExpander>
 
 
             <!--  backup and reset  -->

--- a/FluentSensors/Features/Settings/SettingsPage.xaml
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml
@@ -344,6 +344,29 @@
             </controls:SettingsExpander>
 
 
+            <!--  csv logging settings  -->
+            <TextBlock
+                Margin="1,20,0,6"
+                Style="{StaticResource BodyStrongTextBlockStyle}"
+                Text="CSV Logging" />
+
+            <!--  separators a csv recording is written with  -->
+            <controls:SettingsCard
+                Description="Decimal and column separators a recording is written with"
+                Header="CSV Format"
+                HeaderIcon="{toolkit:FontIcon Glyph=&#xE7C3;}">
+
+                <!--  both entries are labelled from code with the sample row they actually produce  -->
+                <ComboBox
+                    x:Name="CsvNumberFormatComboBox"
+                    Width="230"
+                    SelectionChanged="CsvNumberFormatComboBox_SelectionChanged">
+                    <ComboBoxItem Tag="Local" />
+                    <ComboBoxItem Tag="Invariant" />
+                </ComboBox>
+            </controls:SettingsCard>
+
+
             <!--  backup and reset  -->
             <TextBlock
                 Margin="1,20,0,6"

--- a/FluentSensors/Features/Settings/SettingsPage.xaml.cs
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml.cs
@@ -9,7 +9,6 @@ using FluentSensors.Persistence.Services;
 using FluentSensors.Persistence.Models;
 using FluentSensors.Core;
 using FluentSensors.Common.Csv;
-using FluentSensors.Features.CsvLogging;
 using FluentSensors.Common.Sensors;
 
 
@@ -34,7 +33,7 @@ namespace FluentSensors.Features.Settings
             RestoreThemeSelection();
             RestoreIntervalSelection();
             RestoreMinimizeToTraySelection();
-            RestoreCsvNumberFormatSelection();
+            RestoreCsvFormatSelection();
             RestoreGraphLineStyleSelection();
 
             RestoreBackgroundMaterialSettings();
@@ -160,7 +159,8 @@ namespace FluentSensors.Features.Settings
             MinimizeToTrayToggle.IsOn = SettingsService.Instance.MinimizeToTray;
         }
 
-        // csv number format; only read when a recording starts, so switching it never touches an open file
+        // csv format; all four pieces are only read when a recording starts, so switching any of them never
+        // touches an open file
         private void CsvNumberFormatComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (_isLoading) return;
@@ -170,40 +170,79 @@ namespace FluentSensors.Features.Settings
             {
                 SettingsService.Instance.CsvNumberFormat = format;
             }
+
+            UpdateCsvFormatExample();
         }
 
-        // labels both entries with a sample row instead of a name alone, so the decimal separator and the column
-        // separator are visible side by side
-        // the regional sample is built from the machines own settings rather than a fixed german example; on an
-        // english system it comes out identical to the invariant one, which is exactly what that system writes
-        private void BuildCsvNumberFormatSamples()
+        private void CsvDecimalPlacesComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            foreach (ComboBoxItem item in CsvNumberFormatComboBox.Items)
+            if (_isLoading) return;
+
+            if (CsvDecimalPlacesComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tag
+                && int.TryParse(tag, out int places))
             {
-                if (item.Tag is not string tag || !Enum.TryParse(tag, out CsvNumberFormat format)) continue;
+                SettingsService.Instance.CsvDecimalPlaces = places;
+            }
 
-                var (separator, culture) = CsvLoggingService.ResolveFormat(format);
+            UpdateCsvFormatExample();
+        }
 
-                // a value with decimals and a second column, the shortest row that shows both separators
-                string sample = 2515.862.ToString("0.###", culture) + separator + 41.5.ToString("0.###", culture);
-                string name = format == CsvNumberFormat.Invariant ? "Invariant" : "Regional";
+        private void CsvIncludeUnitsToggle_Toggled(object sender, RoutedEventArgs e)
+        {
+            if (_isLoading) return;
 
-                item.Content = $"{name} ({sample})";
+            SettingsService.Instance.CsvIncludeUnits = CsvIncludeUnitsToggle.IsOn;
+
+            UpdateCsvFormatExample();
+        }
+
+        private void CsvPauseSeamComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+
+            if (CsvPauseSeamComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tag
+                && Enum.TryParse(tag, out CsvPauseSeam seam))
+            {
+                SettingsService.Instance.CsvPauseSeam = seam;
             }
         }
 
-        private void RestoreCsvNumberFormatSelection()
+        private void RestoreCsvFormatSelection()
         {
-            BuildCsvNumberFormatSamples();
+            var settings = SettingsService.Instance;
 
-            string current = SettingsService.Instance.CsvNumberFormat.ToString();
+            SelectByTag(CsvNumberFormatComboBox, settings.CsvNumberFormat.ToString());
+            SelectByTag(CsvDecimalPlacesComboBox, settings.CsvDecimalPlaces.ToString());
+            SelectByTag(CsvPauseSeamComboBox, settings.CsvPauseSeam.ToString());
 
-            foreach (ComboBoxItem item in CsvNumberFormatComboBox.Items)
+            CsvIncludeUnitsToggle.IsOn = settings.CsvIncludeUnits;
+
+            UpdateCsvFormatExample();
+        }
+
+        // one sample row that stands for all four options at once
+        //
+        // built through the same CsvRowFormat a recording uses, so what the expander shows and what lands in the
+        // file can not drift apart; the units come from SensorUnitFormatter for the same reason
+        private void UpdateCsvFormatExample()
+        {
+            var format = CsvRowFormat.Resolve();
+
+            string clock = format.FormatValue(2515.862, SensorUnitFormatter.GetUnit("Clock"));
+            string temperature = format.FormatValue(41.375, SensorUnitFormatter.GetUnit("Temperature"));
+
+            CsvFormatExampleTextBlock.Text = clock + format.Separator + temperature;
+        }
+
+        // picks the entry whose Tag matches, used by every combo box that is restored from a single value
+        private static void SelectByTag(ComboBox comboBox, string tag)
+        {
+            foreach (ComboBoxItem item in comboBox.Items)
             {
-                if (item.Tag?.ToString() == current)
+                if (item.Tag?.ToString() == tag)
                 {
-                    CsvNumberFormatComboBox.SelectedItem = item;
-                    break;
+                    comboBox.SelectedItem = item;
+                    return;
                 }
             }
         }

--- a/FluentSensors/Features/Settings/SettingsPage.xaml.cs
+++ b/FluentSensors/Features/Settings/SettingsPage.xaml.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using FluentSensors.Persistence.Services;
 using FluentSensors.Persistence.Models;
 using FluentSensors.Core;
+using FluentSensors.Common.Csv;
+using FluentSensors.Features.CsvLogging;
 using FluentSensors.Common.Sensors;
 
 
@@ -32,6 +34,7 @@ namespace FluentSensors.Features.Settings
             RestoreThemeSelection();
             RestoreIntervalSelection();
             RestoreMinimizeToTraySelection();
+            RestoreCsvNumberFormatSelection();
             RestoreGraphLineStyleSelection();
 
             RestoreBackgroundMaterialSettings();
@@ -155,6 +158,54 @@ namespace FluentSensors.Features.Settings
         private void RestoreMinimizeToTraySelection()
         {
             MinimizeToTrayToggle.IsOn = SettingsService.Instance.MinimizeToTray;
+        }
+
+        // csv number format; only read when a recording starts, so switching it never touches an open file
+        private void CsvNumberFormatComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_isLoading) return;
+
+            if (CsvNumberFormatComboBox.SelectedItem is ComboBoxItem item && item.Tag is string tag
+                && Enum.TryParse(tag, out CsvNumberFormat format))
+            {
+                SettingsService.Instance.CsvNumberFormat = format;
+            }
+        }
+
+        // labels both entries with a sample row instead of a name alone, so the decimal separator and the column
+        // separator are visible side by side
+        // the regional sample is built from the machines own settings rather than a fixed german example; on an
+        // english system it comes out identical to the invariant one, which is exactly what that system writes
+        private void BuildCsvNumberFormatSamples()
+        {
+            foreach (ComboBoxItem item in CsvNumberFormatComboBox.Items)
+            {
+                if (item.Tag is not string tag || !Enum.TryParse(tag, out CsvNumberFormat format)) continue;
+
+                var (separator, culture) = CsvLoggingService.ResolveFormat(format);
+
+                // a value with decimals and a second column, the shortest row that shows both separators
+                string sample = 2515.862.ToString("0.###", culture) + separator + 41.5.ToString("0.###", culture);
+                string name = format == CsvNumberFormat.Invariant ? "Invariant" : "Regional";
+
+                item.Content = $"{name} ({sample})";
+            }
+        }
+
+        private void RestoreCsvNumberFormatSelection()
+        {
+            BuildCsvNumberFormatSamples();
+
+            string current = SettingsService.Instance.CsvNumberFormat.ToString();
+
+            foreach (ComboBoxItem item in CsvNumberFormatComboBox.Items)
+            {
+                if (item.Tag?.ToString() == current)
+                {
+                    CsvNumberFormatComboBox.SelectedItem = item;
+                    break;
+                }
+            }
         }
 
         // graph line style (stepline / smooth), one global switch for every graph

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -25,6 +25,7 @@ using FluentSensors.Core.Taskbar;
 using FluentSensors.Persistence.Models;
 using FluentSensors.Persistence.Services;
 using FluentSensors.Features.Widget;
+using FluentSensors.Features.CsvLogging;
 
 
 namespace FluentSensors.Features.TaskbarWidget
@@ -806,6 +807,10 @@ namespace FluentSensors.Features.TaskbarWidget
             // 3. Safely destroy and rebuild TaskbarWidgetWindow; the rebuilt widget brings the flyout back itself
             // from the end of its embedding step, see TaskbarWidgetWindow.RecreateWindow
             TaskbarWidgetWindow.RecreateWindow(restoreFlyout: flyoutWasVisible);
+
+            // 4. Safely destroy and rebuild the csv logger window; a running recording is unaffected, it lives in
+            // CsvLoggingService and the rebuilt window just reads it again
+            CsvLoggerWindow.RecreateWindow();
         }
 
 

--- a/FluentSensors/FluentSensors.csproj
+++ b/FluentSensors/FluentSensors.csproj
@@ -44,6 +44,7 @@
 		<None Remove="Controls\SensorGraph\SensorPanelControl.xaml" />
 		<None Remove="Controls\SensorTile\SensorTileControl.xaml" />
 		<None Remove="Controls\Threshold\ThresholdFlyoutControl.xaml" />
+		<None Remove="Features\CsvLogging\CsvLoggerWindow.xaml" />
 		<None Remove="Features\Performance\HardwareViews\CpuDetailView.xaml" />
 		<None Remove="Features\Performance\HardwareViews\GpuDetailView.xaml" />
 		<None Remove="Features\Performance\HardwareViews\MemoryDetailView.xaml" />
@@ -222,6 +223,11 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <Page Update="Controls\SensorTile\SensorTileControl.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </Page>
+	</ItemGroup>
+	<ItemGroup>
+	  <Page Update="Features\CsvLogging\CsvLoggerWindow.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </Page>
 	</ItemGroup>

--- a/FluentSensors/Persistence/Models/AppSettingsData.cs
+++ b/FluentSensors/Persistence/Models/AppSettingsData.cs
@@ -47,6 +47,10 @@ namespace FluentSensors.Persistence.Models
         public bool HideSensorsCompletely { get; set; } = true;
         public bool StatusReadoutEnabled { get; set; } = true;
 
+        // folder csv recordings are written into; empty means the logger falls back to Documents\FluentSensors,
+        // which keeps the default out of the settings file until the user actually picks something
+        public string CsvLogFolder { get; set; } = "";
+
         // lives on HardwareMonitorService at runtime, but conceptually belongs with the rest of the app settings for
         // persistence purposes
         public int UpdateIntervalMs { get; set; } = 500;

--- a/FluentSensors/Persistence/Models/AppSettingsData.cs
+++ b/FluentSensors/Persistence/Models/AppSettingsData.cs
@@ -56,6 +56,16 @@ namespace FluentSensors.Persistence.Models
         // than fed to a script, and an invariant point decimal is silently misread by a localized one
         public CsvNumberFormat CsvNumberFormat { get; set; } = CsvNumberFormat.Local;
 
+        // 3 was the effective maximum before this became configurable, so an existing settings file keeps the
+        // precision it recorded with
+        public int CsvDecimalPlaces { get; set; } = 3;
+
+        // off by default: a value with a unit is text and no longer charts, and the unit is in the column header
+        // either way
+        public bool CsvIncludeUnits { get; set; } = false;
+
+        public CsvPauseSeam CsvPauseSeam { get; set; } = CsvPauseSeam.Gap;
+
         // lives on HardwareMonitorService at runtime, but conceptually belongs with the rest of the app settings for
         // persistence purposes
         public int UpdateIntervalMs { get; set; } = 500;

--- a/FluentSensors/Persistence/Models/AppSettingsData.cs
+++ b/FluentSensors/Persistence/Models/AppSettingsData.cs
@@ -1,5 +1,6 @@
 using Windows.UI;
 
+using FluentSensors.Common.Csv;
 using FluentSensors.Common.Sensors;
 
 
@@ -50,6 +51,10 @@ namespace FluentSensors.Persistence.Models
         // folder csv recordings are written into; empty means the logger falls back to Documents\FluentSensors,
         // which keeps the default out of the settings file until the user actually picks something
         public string CsvLogFolder { get; set; } = "";
+
+        // Local by default: the recording is far more likely to be opened in the spreadsheet app on this machine
+        // than fed to a script, and an invariant point decimal is silently misread by a localized one
+        public CsvNumberFormat CsvNumberFormat { get; set; } = CsvNumberFormat.Local;
 
         // lives on HardwareMonitorService at runtime, but conceptually belongs with the rest of the app settings for
         // persistence purposes

--- a/FluentSensors/Persistence/Services/SettingsService.cs
+++ b/FluentSensors/Persistence/Services/SettingsService.cs
@@ -413,6 +413,23 @@ namespace FluentSensors.Persistence.Services
             }
         }
 
+        // folder csv recordings are written into, picked from the logger window itself
+        // deliberately without a change event, unlike every other property here: the logger window is both the only
+        // writer and the only reader, and it refreshes its own button right after setting this
+        private string _csvLogFolder = "";
+        public string CsvLogFolder
+        {
+            get => _csvLogFolder;
+            set
+            {
+                if (_csvLogFolder != value)
+                {
+                    _csvLogFolder = value;
+                    SaveDebounced();
+                }
+            }
+        }
+
         // persistence
         // writes every property straight to its backing field, skipping change events and the save trigger; used only
         // once at startup, before any window or listener exists yet
@@ -445,6 +462,7 @@ namespace FluentSensors.Persistence.Services
             _minimizeToTray = data.MinimizeToTray;
             _hideSensorsCompletely = data.HideSensorsCompletely;
             _statusReadoutEnabled = data.StatusReadoutEnabled;
+            _csvLogFolder = data.CsvLogFolder ?? "";
 
             // lives on HardwareMonitorService at runtime, not here, but shares this settings file
             HardwareMonitorService.Instance.UpdateIntervalMs = data.UpdateIntervalMs;
@@ -482,6 +500,7 @@ namespace FluentSensors.Persistence.Services
                 MinimizeToTray = _minimizeToTray,
                 HideSensorsCompletely = _hideSensorsCompletely,
                 StatusReadoutEnabled = _statusReadoutEnabled,
+                CsvLogFolder = _csvLogFolder,
                 UpdateIntervalMs = HardwareMonitorService.Instance.UpdateIntervalMs
             };
         }

--- a/FluentSensors/Persistence/Services/SettingsService.cs
+++ b/FluentSensors/Persistence/Services/SettingsService.cs
@@ -448,6 +448,54 @@ namespace FluentSensors.Persistence.Services
             }
         }
 
+        // how many decimals a recorded value carries, written as a fixed count rather than a trimmed one
+        // snapshotted at start like the separators above, for the same reason
+        private int _csvDecimalPlaces = 3;
+        public int CsvDecimalPlaces
+        {
+            get => _csvDecimalPlaces;
+            set
+            {
+                if (_csvDecimalPlaces != value)
+                {
+                    _csvDecimalPlaces = value;
+                    SaveDebounced();
+                }
+            }
+        }
+
+        // whether every value carries its unit next to it; the column header carries it either way
+        private bool _csvIncludeUnits;
+        public bool CsvIncludeUnits
+        {
+            get => _csvIncludeUnits;
+            set
+            {
+                if (_csvIncludeUnits != value)
+                {
+                    _csvIncludeUnits = value;
+                    SaveDebounced();
+                }
+            }
+        }
+
+        // what a resumed recording writes at the seam
+        // unlike the three above this one is read live rather than snapshotted: it only takes effect at the moment
+        // of resuming and cannot invalidate a row that was already written
+        private CsvPauseSeam _csvPauseSeam = CsvPauseSeam.Gap;
+        public CsvPauseSeam CsvPauseSeam
+        {
+            get => _csvPauseSeam;
+            set
+            {
+                if (_csvPauseSeam != value)
+                {
+                    _csvPauseSeam = value;
+                    SaveDebounced();
+                }
+            }
+        }
+
         // persistence
         // writes every property straight to its backing field, skipping change events and the save trigger; used only
         // once at startup, before any window or listener exists yet
@@ -482,6 +530,9 @@ namespace FluentSensors.Persistence.Services
             _statusReadoutEnabled = data.StatusReadoutEnabled;
             _csvLogFolder = data.CsvLogFolder ?? "";
             _csvNumberFormat = data.CsvNumberFormat;
+            _csvDecimalPlaces = data.CsvDecimalPlaces;
+            _csvIncludeUnits = data.CsvIncludeUnits;
+            _csvPauseSeam = data.CsvPauseSeam;
 
             // lives on HardwareMonitorService at runtime, not here, but shares this settings file
             HardwareMonitorService.Instance.UpdateIntervalMs = data.UpdateIntervalMs;
@@ -521,6 +572,9 @@ namespace FluentSensors.Persistence.Services
                 StatusReadoutEnabled = _statusReadoutEnabled,
                 CsvLogFolder = _csvLogFolder,
                 CsvNumberFormat = _csvNumberFormat,
+                CsvDecimalPlaces = _csvDecimalPlaces,
+                CsvIncludeUnits = _csvIncludeUnits,
+                CsvPauseSeam = _csvPauseSeam,
                 UpdateIntervalMs = HardwareMonitorService.Instance.UpdateIntervalMs
             };
         }

--- a/FluentSensors/Persistence/Services/SettingsService.cs
+++ b/FluentSensors/Persistence/Services/SettingsService.cs
@@ -3,6 +3,7 @@ using Windows.UI;
 
 using FluentSensors.Persistence.Models;
 using FluentSensors.Core;
+using FluentSensors.Common.Csv;
 using FluentSensors.Common.Sensors;
 
 
@@ -430,6 +431,23 @@ namespace FluentSensors.Persistence.Services
             }
         }
 
+        // separators a recording is written with
+        // no change event either, for the same reason as the folder above: CsvLoggingService snapshots this once
+        // when a recording starts, since switching separators inside an open file would corrupt it
+        private CsvNumberFormat _csvNumberFormat = CsvNumberFormat.Local;
+        public CsvNumberFormat CsvNumberFormat
+        {
+            get => _csvNumberFormat;
+            set
+            {
+                if (_csvNumberFormat != value)
+                {
+                    _csvNumberFormat = value;
+                    SaveDebounced();
+                }
+            }
+        }
+
         // persistence
         // writes every property straight to its backing field, skipping change events and the save trigger; used only
         // once at startup, before any window or listener exists yet
@@ -463,6 +481,7 @@ namespace FluentSensors.Persistence.Services
             _hideSensorsCompletely = data.HideSensorsCompletely;
             _statusReadoutEnabled = data.StatusReadoutEnabled;
             _csvLogFolder = data.CsvLogFolder ?? "";
+            _csvNumberFormat = data.CsvNumberFormat;
 
             // lives on HardwareMonitorService at runtime, not here, but shares this settings file
             HardwareMonitorService.Instance.UpdateIntervalMs = data.UpdateIntervalMs;
@@ -501,6 +520,7 @@ namespace FluentSensors.Persistence.Services
                 HideSensorsCompletely = _hideSensorsCompletely,
                 StatusReadoutEnabled = _statusReadoutEnabled,
                 CsvLogFolder = _csvLogFolder,
+                CsvNumberFormat = _csvNumberFormat,
                 UpdateIntervalMs = HardwareMonitorService.Instance.UpdateIntervalMs
             };
         }

--- a/FluentSensors/Persistence/Services/Win32FileDialogHelper.cs
+++ b/FluentSensors/Persistence/Services/Win32FileDialogHelper.cs
@@ -20,8 +20,8 @@ namespace FluentSensors.Persistence.Services
     {
         // === public api ===
 
-        // thin synchronous wrappers around the native dialogs; both return the picked path, or null if the user
-        // cancelled or the dialog failed, and release the COM object again immediately after use
+        // thin synchronous wrappers around the native dialogs; all of them return the picked path, or null if the
+        // user cancelled or the dialog failed, and release the COM object again immediately after use
 
         // returns the picked file path, or null if the user cancelled (or the dialog failed)
         public static string PickSaveFile(IntPtr ownerHwnd, string title, string suggestedFileName, string filterName, string filterExtension)
@@ -73,12 +73,61 @@ namespace FluentSensors.Persistence.Services
         }
 
 
+        // picks a folder rather than a file, by putting the same open dialog into folder mode via FOS_PICKFOLDERS
+        // initialFolder is where the dialog opens; ignored when it does not exist anymore, Windows then falls back to
+        // its own last-used location
+        public static string PickFolder(IntPtr ownerHwnd, string title, string initialFolder)
+        {
+            var dialog = (IFileOpenDialog)new FileOpenDialogRCW();
+            try
+            {
+                dialog.SetTitle(title);
+
+                dialog.GetOptions(out uint options);
+                dialog.SetOptions(options | FOS_PICKFOLDERS);
+
+                if (!string.IsNullOrEmpty(initialFolder))
+                {
+                    try
+                    {
+                        var guid = IID_IShellItem;
+                        if (SHCreateItemFromParsingName(initialFolder, IntPtr.Zero, ref guid, out var startItem) == 0)
+                        {
+                            dialog.SetFolder(startItem);
+                            Marshal.ReleaseComObject(startItem);
+                        }
+                    }
+                    catch { /* only the starting location, a failure here still leaves a usable dialog */ }
+                }
+
+                if (dialog.Show(ownerHwnd) != 0) return null; // non-zero HRESULT: user cancelled or dialog failed
+
+                dialog.GetResult(out var item);
+                item.GetDisplayName(SIGDN.FILESYSPATH, out var path);
+                return path;
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(dialog);
+            }
+        }
+
+
         // === com interop declarations ===
 
         // manual COM interop instead of the CsWin32 source generator Microsofts docs suggest, to keep this
         // self-contained
-        // minimal subset of shobjidl_core.h; just enough surface for a single-file save/open dialog, not a general-purpose
-        // wrapper (no multi-select, no folder picking, no custom places)
+        // minimal subset of shobjidl_core.h; just enough surface for a single-file save/open dialog plus folder
+        // picking, not a general-purpose wrapper (no multi-select, no custom places)
+
+        // FOS_PICKFOLDERS, the _FILEOPENDIALOGOPTIONS flag that turns the open dialog into a folder browser
+        private const uint FOS_PICKFOLDERS = 0x00000020;
+
+        private static Guid IID_IShellItem = new Guid("43826d1e-e718-42ee-bc55-a1e261c37bfe");
+
+        [DllImport("shell32.dll", CharSet = CharSet.Unicode, PreserveSig = true)]
+        private static extern int SHCreateItemFromParsingName(
+            [MarshalAs(UnmanagedType.LPWStr)] string pszPath, IntPtr pbc, ref Guid riid, out IShellItem ppv);
 
         [ComImport, Guid("42f85136-db7e-439c-85f1-e4075d135fc8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         private interface IFileDialog


### PR DESCRIPTION
## What does this change

Adds CSV recording for the sensors selected on the sensors page, driven from a small
always-on-top logger window.

- `CsvLoggingService` owns the recording rather than the window: it survives closing the
  logger and the full window rebuild that a theme or transparency change triggers
- Logger window with start, stop and pause, a live elapsed and row counter, a collapsible
  details region and a folder picker
- Pause holds the recording without releasing the file; resuming can leave a one row gap so
  a chart breaks its line instead of interpolating across a stretch that was never measured
- The main bar shows the recorded stretch, not the wall clock, so it can never contradict
  the row counter next to it; total elapsed and the pause count sit in the details region
- CSV format expander in the settings: regional or invariant separators, 0 to 3 fixed
  decimal places, units next to values and the pause behaviour, with a live example row
  built from the same formatter that writes the file
- Folder picking added to the existing `Win32FileDialogHelper` through `FOS_PICKFOLDERS`
- New `SubtleBarButtonStyle` in `App.xaml`: the state brushes of the platform subtle button
  without its border arriving a frame ahead of the fill

Part of #23

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English