### PR TITLE
Tighten the comments in the CSV logging code

### DIFF
--- a/FluentSensors/Features/CsvLogging/CsvLoggerViewModel.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerViewModel.cs
@@ -22,8 +22,7 @@ namespace FluentSensors.Features.CsvLogging
         private readonly DispatcherQueue _dispatcherQueue;
         private DispatcherQueueTimer _tickTimer;
 
-        // how often the elapsed clock and the row counter are re-read while recording; unrelated to the sensor poll
-        // interval, this only drives text
+        // how often the elapsed clock and the row counter are updated in UI
         private const int TickIntervalMs = 500;
 
         // whether the window is actually on screen; a hidden or minimized logger stops ticking, the recording in
@@ -108,7 +107,6 @@ namespace FluentSensors.Features.CsvLogging
             }
         }
 
-        // the stretch covered by rows, which is what the main bar shows next to the row counter
         private string _recordedElapsedText = "00:00:00";
         public string RecordedElapsedText
         {
@@ -121,8 +119,6 @@ namespace FluentSensors.Features.CsvLogging
             }
         }
 
-        // wall clock since start, pauses included; only shown in the details region, and the value that matches
-        // the elapsed column in the file
         private string _totalElapsedText = "00:00:00";
         public string TotalElapsedText
         {
@@ -135,7 +131,6 @@ namespace FluentSensors.Features.CsvLogging
             }
         }
 
-        // the reason the two durations above differ
         private string _pauseCountText = "0";
         public string PauseCountText
         {
@@ -172,7 +167,7 @@ namespace FluentSensors.Features.CsvLogging
             }
         }
 
-        // elapsed clock and row counter in one line, for the main bar where a single value has to carry both
+        // elapsed clock and row counter for the main bar
         private string _elapsedRowsText = "00:00:00 | 0";
         public string ElapsedRowsText
         {
@@ -357,7 +352,7 @@ namespace FluentSensors.Features.CsvLogging
             StatusText = BuildStatusText();
         }
 
-        // the rate the user set, not the measured one; a number that only moves when they move it
+        // set polling rate
         private static string FormatPolling()
         {
             return $"{HardwareMonitorService.Instance.UpdateIntervalMs} ms";

--- a/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggingService.cs
@@ -16,8 +16,9 @@ using FluentSensors.Persistence.Services;
 
 namespace FluentSensors.Features.CsvLogging
 {
-    // one column of a recording: the sensor id every payload is matched against, plus the header text written once
-    // into the first line of the file
+    // one column of a recording:
+    // the sensor id every payload is matched against, plus the header text written once into the first line of
+    // the file
     public class CsvLoggedSensor
     {
         public CsvLoggedSensor(string id, string header, string unit)
@@ -51,9 +52,9 @@ namespace FluentSensors.Features.CsvLogging
         // while the sensors page is replacing it
         private CsvLoggedSensor[] _activeColumns;
 
-        // the format the open file was started with, snapshotted the same way _activeColumns is: a switch of the
-        // separators, the decimal count or the units midway through a recording would leave one half of the file
-        // formatted differently from the other, and nothing reading it would notice
+        // the format the open file was started with, snapshotted the same way _activeColumns is:
+        // a switch of the separators, the decimal count or the units midway through a recording would leave one
+        // half of the file formatted differently from the other, and nothing reading it would notice
         private CsvRowFormat _rowFormat;
 
         // how much of Elapsed was spent holding, and how often; both reset with every fresh start


### PR DESCRIPTION
## What does this change

Comment-only cleanup in the CSV logging service and view model, left over from #23.
No behaviour, API or formatting changes.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English