### PR TITLE
Fix the title bar back button and restyle the flyout bottom bar

### DIFF
--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -186,9 +186,6 @@
                 outline in the final color around a still empty button
                 every state brush below is the one the platform style uses, the border just stays transparent in
                 all of them, and the fill is sized to the outer border edge so it still covers the full box
-                Foreground is template bound on the ContentPresenter exactly as the platform template does it;
-                inheritance does not reach the content, so without that binding a Foreground set on the button is
-                ignored and the text renders in the default color
             -->
             <Style x:Key="SubtleBarButtonStyle" TargetType="Button">
                 <Setter Property="Background" Value="{ThemeResource SubtleButtonBackground}" />

--- a/FluentSensors/App.xaml
+++ b/FluentSensors/App.xaml
@@ -186,6 +186,9 @@
                 outline in the final color around a still empty button
                 every state brush below is the one the platform style uses, the border just stays transparent in
                 all of them, and the fill is sized to the outer border edge so it still covers the full box
+                Foreground is template bound on the ContentPresenter exactly as the platform template does it;
+                inheritance does not reach the content, so without that binding a Foreground set on the button is
+                ignored and the text renders in the default color
             -->
             <Style x:Key="SubtleBarButtonStyle" TargetType="Button">
                 <Setter Property="Background" Value="{ThemeResource SubtleButtonBackground}" />
@@ -218,7 +221,8 @@
                                 Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}"
                                 ContentTransitions="{TemplateBinding ContentTransitions}"
-                                CornerRadius="{TemplateBinding CornerRadius}">
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                Foreground="{TemplateBinding Foreground}">
                                 <!--  the value of ControlFasterAnimationDuration  -->
                                 <!--  (spelled out because BrushTransition.Duration is a TimeSpan and the platform keys are strings; the platform button hardcodes it the same way)  -->
                                 <ContentPresenter.BackgroundTransition>

--- a/FluentSensors/Common/UI/TitleBarPassthrough.cs
+++ b/FluentSensors/Common/UI/TitleBarPassthrough.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+
+using Windows.Foundation;
+using Windows.Graphics;
+
+
+namespace FluentSensors.Common.UI
+{
+    // registers interactive titlebar elements as client passthrough regions so pointer events (pressed visual state)
+    // are consumed by the controls themselves rather than initiating a window drag
+    //
+    // every window that hands a custom bar to SetTitleBar needs this; the whole bar is non-client otherwise, and a
+    // button sitting in it never sees a press, it only moves the window
+    public static class TitleBarPassthrough
+    {
+        // rects are absolute window coordinates, so this has to run again whenever the bar is laid out or one of the
+        // elements moves, appears or disappears
+        public static void Apply(Window window, FrameworkElement titleBar, params FrameworkElement[] elements)
+        {
+            if (window == null || titleBar == null || !titleBar.IsLoaded) return;
+
+            try
+            {
+                var nonClientInputSrc = InputNonClientPointerSource.GetForWindowId(window.AppWindow.Id);
+                if (nonClientInputSrc == null) return;
+
+                double scale = titleBar.XamlRoot?.RasterizationScale ?? 1.0;
+                var rects = new List<RectInt32>();
+
+                foreach (var element in elements)
+                {
+                    AddPassthroughRect(rects, element, scale);
+                }
+
+                nonClientInputSrc.SetRegionRects(NonClientRegionKind.Passthrough, rects.ToArray());
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[TitleBarPassthrough] failed: {ex.Message}");
+            }
+        }
+
+        private static void AddPassthroughRect(List<RectInt32> rects, FrameworkElement element, double scale)
+        {
+            if (element == null || element.Visibility != Visibility.Visible || !element.IsLoaded) return;
+
+            try
+            {
+                var transform = element.TransformToVisual(null);
+                var bounds = transform.TransformBounds(new Rect(0, 0, element.ActualWidth, element.ActualHeight));
+                if (bounds.Width > 0 && bounds.Height > 0)
+                {
+                    rects.Add(new RectInt32(
+                        (int)Math.Round(bounds.X * scale),
+                        (int)Math.Round(bounds.Y * scale),
+                        (int)Math.Round(bounds.Width * scale),
+                        (int)Math.Round(bounds.Height * scale)
+                    ));
+                }
+            }
+            catch
+            {
+                // an element caught mid-teardown simply contributes no rect
+            }
+        }
+    }
+}

--- a/FluentSensors/Common/UI/TitleBarPassthrough.cs
+++ b/FluentSensors/Common/UI/TitleBarPassthrough.cs
@@ -14,8 +14,8 @@ namespace FluentSensors.Common.UI
     // registers interactive titlebar elements as client passthrough regions so pointer events (pressed visual state)
     // are consumed by the controls themselves rather than initiating a window drag
     //
-    // every window that hands a custom bar to SetTitleBar needs this; the whole bar is non-client otherwise, and a
-    // button sitting in it never sees a press, it only moves the window
+    // SetTitleBar turns the whole bar non-client, so any window with an interactive element in there needs this;
+    // without a rect of its own that element never sees a press, the pointer only moves the window
     public static class TitleBarPassthrough
     {
         // rects are absolute window coordinates, so this has to run again whenever the bar is laid out or one of the

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml
@@ -33,6 +33,7 @@
 
                 <!--  back to main application button (same one the widget window carries)  -->
                 <Button
+                    x:Name="BackToDashboardButton"
                     Width="32"
                     Padding="0"
                     VerticalAlignment="Stretch"
@@ -231,8 +232,10 @@
                     </StackPanel>
 
                     <!--  wall clock since start, pauses included  -->
-                    <!--  (the main bar shows the recorded stretch instead; this is the one that matches the
-                          elapsed column in the file)  -->
+                    <!--
+                        (the main bar shows the recorded stretch instead; this is the one that matches the
+                        elapsed column in the file)
+                    -->
                     <StackPanel Width="Auto" Spacing="2">
                         <TextBlock
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"

--- a/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
+++ b/FluentSensors/Features/CsvLogging/CsvLoggerWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using WinRT;
 
+using FluentSensors.Common.UI;
 using FluentSensors.Controls.SensorRow;
 using FluentSensors.Features.TaskbarWidget;
 using FluentSensors.Persistence.Models;
@@ -86,6 +87,11 @@ namespace FluentSensors.Features.CsvLogging
             _appWindow = this.AppWindow;
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(CustomTitleBar);
+
+            // the back button sits inside the drag region, so it needs its own passthrough rect to ever see a press
+            CustomTitleBar.Loaded += (s, e) => UpdateTitleBarPassthroughRegions();
+            CustomTitleBar.SizeChanged += (s, e) => UpdateTitleBarPassthroughRegions();
+
             var presenter = OverlappedPresenter.Create();
             presenter.IsAlwaysOnTop = true; // same as the widget, a running recording has to stay readable over other apps
             presenter.IsMaximizable = false;
@@ -457,6 +463,13 @@ namespace FluentSensors.Features.CsvLogging
             if (picked == null) return; // user cancelled
 
             ViewModel.SetLogFolder(picked);
+        }
+
+        // low priority so the rect is read after the bar has actually been laid out, same as MainWindow does it
+        private void UpdateTitleBarPassthroughRegions()
+        {
+            this.DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low,
+                () => TitleBarPassthrough.Apply(this, CustomTitleBar, BackToDashboardButton));
         }
 
         private void BackToDashboard_Click(object sender, RoutedEventArgs e)

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -95,7 +95,6 @@
                 <Grid x:Name="BottomBarContentGrid">
 
                     <!--  open the sensor list on the taskbar profile  -->
-                    <!--  (label only)  -->
                     <Button
                         x:Name="BackToDashboardButton"
                         Padding="11,0,11,0"
@@ -107,7 +106,6 @@
                         Style="{StaticResource SubtleBarButtonStyle}" />
 
                     <!--  close taskbar widget  -->
-                    <!--  (icon only)  -->
                     <Button
                         x:Name="CloseWidgetButton"
                         Width="38"

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml
@@ -86,76 +86,39 @@
             <Border
                 x:Name="FlyoutBottomBarBorder"
                 Grid.Row="1"
+                Margin="0,0,0,1"
                 Background="{ThemeResource FlyoutBottomBarBackground}"
                 BorderBrush="{ThemeResource FlyoutBottomBarSeparatorBrush}"
                 BorderThickness="0,1,0,0"
                 CornerRadius="0,0,7,7">
 
                 <Grid x:Name="BottomBarContentGrid">
-                    <Grid.Resources>
-                        <SolidColorBrush x:Key="CommandBarBackground" Color="Transparent" />
-                        <SolidColorBrush x:Key="CommandBarBackgroundOpen" Color="Transparent" />
-                        <SolidColorBrush x:Key="CommandBarBorderBrushOpen" Color="Transparent" />
-
-                        <Thickness x:Key="AppBarButtonPadding">0,0,0,0</Thickness>
-                    </Grid.Resources>
 
                     <!--  open the sensor list on the taskbar profile  -->
                     <!--  (label only)  -->
-                    <CommandBar
+                    <Button
+                        x:Name="BackToDashboardButton"
+                        Padding="11,0,11,0"
                         HorizontalAlignment="Left"
-                        Background="Transparent"
-                        DefaultLabelPosition="Right"
-                        IsDynamicOverflowEnabled="False"
-                        IsOpen="False"
-                        OverflowButtonVisibility="Collapsed">
-                        <CommandBar.PrimaryCommands>
-                            <AppBarButton
-                                x:Name="BackToDashboardButton"
-                                Click="BackToDashboard_Click"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Label="Manage Taskbar Sensors">
-
-                                <!--  runs without an icon; the glyph column is sized by the LabelOnRight visual state  -->
-                                <!--
-                                    the label margin itself is unreachable: the LabelOnRight state assigns it from a
-                                    StaticResource, which resolves once inside the platform dictionary and never looks
-                                    at this scope, so its fixed 8,16,12,10 always wins
-                                -->
-                                <AppBarButton.Resources>
-                                    <x:Double x:Key="AppBarButtonContentHeight">0</x:Double>
-                                    <Thickness x:Key="AppBarButtonContentViewboxMargin">5,0,0,0</Thickness>
-                                </AppBarButton.Resources>
-                            </AppBarButton>
-                        </CommandBar.PrimaryCommands>
-                    </CommandBar>
+                        Click="BackToDashboard_Click"
+                        Content="Manage Taskbar Sensors"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource SubtleBarButtonStyle}" />
 
                     <!--  close taskbar widget  -->
                     <!--  (icon only)  -->
-                    <CommandBar
+                    <Button
+                        x:Name="CloseWidgetButton"
+                        Width="38"
+                        Padding="0"
                         HorizontalAlignment="Right"
-                        Background="Transparent"
-                        DefaultLabelPosition="Collapsed"
-                        IsDynamicOverflowEnabled="False"
-                        IsOpen="False"
-                        OverflowButtonVisibility="Collapsed">
-                        <CommandBar.PrimaryCommands>
-                            <AppBarButton
-                                x:Name="CloseWidgetButton"
-                                Width="44"
-                                Click="CloseWidget_Click"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Label="Close Taskbar Widget"
-                                ToolTipService.ToolTip="Close Taskbar Widget">
-                                <AppBarButton.Icon>
-                                    <FontIcon
-                                        FontSize="10.5"
-                                        FontWeight="SemiLight"
-                                        Glyph="&#xE711;" />
-                                </AppBarButton.Icon>
-                            </AppBarButton>
-                        </CommandBar.PrimaryCommands>
-                    </CommandBar>
+                        Click="CloseWidget_Click"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource SubtleBarButtonStyle}"
+                        ToolTipService.ToolTip="Close Taskbar Widget">
+                        <FontIcon FontSize="14" Glyph="&#xE711;" />
+                    </Button>
                 </Grid>
             </Border>
         </Grid>

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -206,18 +206,15 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // --- flyout layout ---
 
-        // the two knobs for the interior; every visible inset inside the window comes from one of them
-        // the graphs inset is a margin on the list rather than padding on the surface below it, so the scroll region
-        // stays the full width of the window and the scrollbar rides its edge instead of sitting 6px inside
-        public static readonly Thickness FlyoutGraphsMargin = new Thickness(6, 9, 6, 7);
-        public static readonly Thickness FlyoutBottomBarPadding = new Thickness(0, 0, 0, 0);
+        // padding settings
+        public static readonly Thickness FlyoutGraphsMargin = new Thickness(6, 9, 6, 8);
+        public static readonly Thickness FlyoutBottomBarPadding = new Thickness(6, 5, 6, 5);
 
         // gap between two stacked graphs
         public const double FlyoutGraphSpacingDip = 8;
 
-        // (AppBarButton renders at the platform AppBarThemeCompactHeight; mirrored here because the window height
-        // math runs long before the bar is ever measured)
-        public const double FlyoutBottomBarButtonHeightDip = 48;
+        // bottom bar button height
+        public const double FlyoutBottomBarButtonHeightDip = 36;
 
         // separator drawn as the top border of FlyoutBottomBarBorder
         private const double FlyoutBottomBarSeparatorDip = 1;
@@ -347,6 +344,8 @@ namespace FluentSensors.Features.TaskbarWidget
             // the interior is driven entirely from the layout metrics above, the XAML carries no numbers of its own
             GraphsItemsControl.Margin = FlyoutGraphsMargin;
             BottomBarContentGrid.Padding = FlyoutBottomBarPadding;
+            BackToDashboardButton.Height = FlyoutBottomBarButtonHeightDip;
+            CloseWidgetButton.Height = FlyoutBottomBarButtonHeightDip;
             GraphsItemsControl.LayoutUpdated += OnGraphsItemsControlLayoutUpdated;
 
             _appWindow.Changed += AppWindow_Changed;

--- a/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarFlyoutWindow.xaml.cs
@@ -206,14 +206,17 @@ namespace FluentSensors.Features.TaskbarWidget
 
         // --- flyout layout ---
 
-        // padding settings
+        // the two insets the interior is built from;
+        // the graphs inset is a margin on the list rather than padding on the surface below it, so the scroll region
+        // stays the full width of the window and the scrollbar rides the window edge instead of the inset
         public static readonly Thickness FlyoutGraphsMargin = new Thickness(6, 9, 6, 8);
         public static readonly Thickness FlyoutBottomBarPadding = new Thickness(6, 5, 6, 5);
 
         // gap between two stacked graphs
         public const double FlyoutGraphSpacingDip = 8;
 
-        // bottom bar button height
+        // height of both bottom bar buttons, assigned to them further down; the window height math runs long before
+        // the bar is ever measured, so the value cannot be read back off the controls
         public const double FlyoutBottomBarButtonHeightDip = 36;
 
         // separator drawn as the top border of FlyoutBottomBarBorder
@@ -341,7 +344,9 @@ namespace FluentSensors.Features.TaskbarWidget
                 });
             };
 
-            // the interior is driven entirely from the layout metrics above, the XAML carries no numbers of its own
+            // the insets and the bar button height come from the layout constants above, which is what keeps the
+            // window height math and the rendered bar in sync; width and padding of the buttons themselves stay in
+            // the xaml, they do not enter that math
             GraphsItemsControl.Margin = FlyoutGraphsMargin;
             BottomBarContentGrid.Padding = FlyoutBottomBarPadding;
             BackToDashboardButton.Height = FlyoutBottomBarButtonHeightDip;

--- a/FluentSensors/Features/Widget/WidgetWindow.xaml
+++ b/FluentSensors/Features/Widget/WidgetWindow.xaml
@@ -27,6 +27,7 @@
 
             <!--  back to main application button (currently in title bar too)  -->
             <Button
+                x:Name="BackToDashboardButton"
                 Width="32"
                 Height="22"
                 Margin="4,4,0,0"

--- a/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
+++ b/FluentSensors/Features/Widget/WidgetWindow.xaml.cs
@@ -16,6 +16,7 @@ using FluentSensors.Controls.SensorRow;
 using FluentSensors.Controls.SensorGraph;
 using FluentSensors.Features.Sensors;
 using FluentSensors.Common.Sensors;
+using FluentSensors.Common.UI;
 using FluentSensors.Features.TaskbarWidget;
 
 
@@ -68,6 +69,11 @@ namespace FluentSensors.Features.Widget
             _appWindow = this.AppWindow;
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(CustomTitleBar);
+
+            // the back button sits inside the drag region, so it needs its own passthrough rect to ever see a press
+            CustomTitleBar.Loaded += (s, e) => UpdateTitleBarPassthroughRegions();
+            CustomTitleBar.SizeChanged += (s, e) => UpdateTitleBarPassthroughRegions();
+
             var presenter = OverlappedPresenter.Create();
             presenter.IsAlwaysOnTop = true; // replaces the CompactOverlay behavior
             presenter.IsMaximizable = false;
@@ -387,6 +393,13 @@ namespace FluentSensors.Features.Widget
 
 
         // === user interaction ===
+
+        // low priority so the rect is read after the bar has actually been laid out, same as MainWindow does it
+        private void UpdateTitleBarPassthroughRegions()
+        {
+            this.DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low,
+                () => TitleBarPassthrough.Apply(this, CustomTitleBar, BackToDashboardButton));
+        }
 
         private void BackToDashboard_Click(object sender, RoutedEventArgs e)
         {

--- a/FluentSensors/MainWindow.xaml.cs
+++ b/FluentSensors/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using FluentSensors.Features.Settings;
 using FluentSensors.Features.Widget;
 using FluentSensors.Persistence.Services;
 using FluentSensors.Common.Sensors;
+using FluentSensors.Common.UI;
 
 
 namespace FluentSensors
@@ -350,54 +351,12 @@ namespace FluentSensors
             this.DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, UpdateTitleBarPassthroughRegions);
         }
 
-        // registers interactive titlebar elements as client passthrough regions so pointer events (pressed visual state)
-        // are consumed by the controls themselves rather than initiating a window drag
+        // the four interactive elements sitting in the drag region; the status toggle hides and shows the two groups
+        // next to it, so the rects are recomputed rather than registered once
         private void UpdateTitleBarPassthroughRegions()
         {
-            if (AppTitleBar == null || !AppTitleBar.IsLoaded) return;
-
-            try
-            {
-                var nonClientInputSrc = Microsoft.UI.Input.InputNonClientPointerSource.GetForWindowId(this.AppWindow.Id);
-                if (nonClientInputSrc == null) return;
-
-                double scale = AppTitleBar.XamlRoot?.RasterizationScale ?? 1.0;
-                var rects = new List<Windows.Graphics.RectInt32>();
-
-                AddPassthroughRect(rects, DotNetRuntimePopup, scale);
-                AddPassthroughRect(rects, StatusToggleButton, scale);
-                AddPassthroughRect(rects, LhmInfoPopup, scale);
-                AddPassthroughRect(rects, WindowsInfoPopup, scale);
-
-                nonClientInputSrc.SetRegionRects(Microsoft.UI.Input.NonClientRegionKind.Passthrough, rects.ToArray());
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"[UpdateTitleBarPassthroughRegions] failed: {ex.Message}");
-            }
-        }
-
-        private void AddPassthroughRect(List<Windows.Graphics.RectInt32> rects, FrameworkElement element, double scale)
-        {
-            if (element == null || element.Visibility != Visibility.Visible || !element.IsLoaded) return;
-
-            try
-            {
-                var transform = element.TransformToVisual(null);
-                var bounds = transform.TransformBounds(new Windows.Foundation.Rect(0, 0, element.ActualWidth, element.ActualHeight));
-                if (bounds.Width > 0 && bounds.Height > 0)
-                {
-                    rects.Add(new Windows.Graphics.RectInt32(
-                        (int)Math.Round(bounds.X * scale),
-                        (int)Math.Round(bounds.Y * scale),
-                        (int)Math.Round(bounds.Width * scale),
-                        (int)Math.Round(bounds.Height * scale)
-                    ));
-                }
-            }
-            catch
-            {
-            }
+            TitleBarPassthrough.Apply(this, AppTitleBar,
+                DotNetRuntimePopup, StatusToggleButton, LhmInfoPopup, WindowsInfoPopup);
         }
 
         // plain Button standing in for a real ToggleButton, see the XAML comment on it for why


### PR DESCRIPTION
## What does this change

The back button in the CSV logger and widget window never showed a press state:
both windows hand their whole custom bar to `SetTitleBar`, so the bar is non-client
and the pointer starts a window drag instead of reaching the button. `MainWindow`
already solved this with explicit passthrough regions; that code moves into
`Common/UI/TitleBarPassthrough` and all three windows now share it.

The two buttons in the taskbar flyout bottom bar were `AppBarButton`s inside
`CommandBar`s, which is why they looked and behaved unlike every other button in
the app. They are plain buttons on `SubtleBarButtonStyle` now, with a 4px inset on
all sides.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English