### PR TITLE
Persist the taskbar widget position and the active sensor profile

### DIFF
--- a/FluentSensors/Features/Sensors/SensorsPage.xaml.cs
+++ b/FluentSensors/Features/Sensors/SensorsPage.xaml.cs
@@ -15,6 +15,7 @@ using FluentSensors.Features.TaskbarWidget;
 using FluentSensors.Features.CsvLogging;
 using FluentSensors.Common.UI;
 using FluentSensors.Common.Sensors;
+using FluentSensors.Persistence.Services;
 
 
 namespace FluentSensors.Features.Sensors
@@ -53,6 +54,15 @@ namespace FluentSensors.Features.Sensors
         {
             this.InitializeComponent();
             ViewModel = SensorsViewModel.Instance;
+
+            // come back on the profile the page was last switched to;
+            // Deliberately still under the loading guard: the SelectionChanged handler would rebuild the command bar
+            // from here, before SensorListCommandBar_Loaded has set up its overflow state; that Loaded handler builds
+            // the bar from ViewModel.ActiveProfile a moment later anyway, so the profile only has to be in place
+            var lastProfile = SettingsService.Instance.LastSensorProfile;
+            ViewModel.ActiveProfile = lastProfile;
+            SelectProfile(lastProfile);
+
             _isLoading = false;
         }
 
@@ -170,6 +180,7 @@ namespace FluentSensors.Features.Sensors
             if (selectedItem.Tag is not string tag || !Enum.TryParse(tag, out SensorSelectionProfile profile)) return;
 
             ViewModel.ActiveProfile = profile;
+            SettingsService.Instance.LastSensorProfile = profile;
             RebuildCommandBarOverflow();
         }
 

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -1021,6 +1021,8 @@ namespace FluentSensors.Features.TaskbarWidget
             var ptr = e?.GetCurrentPoint(TaskbarButton);
             if (ptr != null && !ptr.Properties.IsLeftButtonPressed) return;
 
+            _suppressClick = false;
+
             // skip all drag bookkeeping while the position is locked; press feedback and click-to-toggle stay live
             if (!SettingsService.Instance.TaskbarWidgetPositionLocked && NativeMethods.GetCursorPos(out var cursorPos))
             {
@@ -1028,7 +1030,6 @@ namespace FluentSensors.Features.TaskbarWidget
                 _dragStartWindowScreenX = _currentScreenRect.X;
                 _isPotentialDrag = true;
                 _isDragging = false;
-                _suppressClick = false;
 
                 var primaryTaskbar = WinTaskbarService.Instance.DiscoverNow().FirstOrDefault();
                 if (primaryTaskbar != null)
@@ -1054,6 +1055,14 @@ namespace FluentSensors.Features.TaskbarWidget
             if (!_isDragging && Math.Abs(deltaX) >= DragThresholdPixels)
             {
                 _isDragging = true;
+
+                // the click guard goes up here, at the first moved pixel, rather than when the drag ends
+                // ButtonBase raises Click from inside its own PointerReleased class handler, and that class handler
+                // runs ahead of our instance handlers; both the release we listen to and the capture loss therefore
+                // arrive after the click has already been raised, so a guard set at drag end is always too late
+                // it stays up until the next press clears it, which also covers releasing outside the widget
+                _suppressClick = true;
+
                 if (e != null)
                 {
                     TaskbarButton.CapturePointer(e.Pointer);
@@ -1088,8 +1097,7 @@ namespace FluentSensors.Features.TaskbarWidget
                 try { TaskbarButton.ReleasePointerCapture(e.Pointer); } catch { }
             }
 
-            CommitDragEnd();
-            _isPotentialDrag = false;
+            EndDrag();
 
             _isPressed = false;
 
@@ -1106,43 +1114,29 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private void TaskbarButton_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
         {
-            EndDragOrClearClickGuard();
+            EndDrag();
             TaskbarButton_PointerExited(sender, e);
         }
 
         private void TaskbarButton_PointerCanceled(object sender, PointerRoutedEventArgs e)
         {
-            EndDragOrClearClickGuard();
+            EndDrag();
             TaskbarButton_PointerExited(sender, e);
         }
 
-        // the single place a drag is committed; the offset only lives in _currentOffsetDip until this runs
+        // the single place a drag is committed; the moved offset only lives in _currentOffsetDip until this runs
         //
-        // ButtonBase releases the pointer capture from inside its own PointerReleased class handler, which runs
-        // ahead of our instance handler, so the capture loss can be the first of the two to arrive; whichever gets
-        // here first does the save and the other one finds nothing left to do
-        private void CommitDragEnd()
-        {
-            if (!_isDragging) return;
-
-            _isDragging = false;
-            _isPotentialDrag = false;
-            _suppressClick = true;
-            SaveWindowState(wasOpen: true);
-        }
-
-        // a capture loss or cancellation mid drag still ends the drag: the window sits at its new position already,
-        // so the offset is kept rather than dropped
-        // without a drag in flight there is nothing to swallow and the click guard is released instead
-        private void EndDragOrClearClickGuard()
+        // releasing the pointer produces both a PointerReleased and a PointerCaptureLost, in an order that is not
+        // guaranteed, and a capture can also be lost mid drag with no release at all; every one of those paths ends
+        // the drag, so whichever arrives first saves and the rest find nothing left to do
+        // the click guard is deliberately not set here, see TaskbarButton_PointerMoved for why it has to go up at the
+        // start of the drag instead
+        private void EndDrag()
         {
             if (_isDragging)
             {
-                CommitDragEnd();
-            }
-            else
-            {
-                _suppressClick = false;
+                _isDragging = false;
+                SaveWindowState(wasOpen: true);
             }
 
             _isPotentialDrag = false;

--- a/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
+++ b/FluentSensors/Features/TaskbarWidget/TaskbarWidgetWindow.xaml.cs
@@ -153,7 +153,7 @@ namespace FluentSensors.Features.TaskbarWidget
                 if (!_isRebuild)
                 {
                     var savedState = WindowStateService.Instance.GetState(WindowKey);
-                    if (savedState != null && savedState.X > 0)
+                    if (savedState != null && savedState.X >= 0)
                     {
                         _currentOffsetDip = savedState.X;
                     }
@@ -1083,21 +1083,13 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private void TaskbarButton_PointerReleased(object sender, PointerRoutedEventArgs e)
         {
-            if (_isDragging)
+            if (_isDragging && e != null)
             {
-                if (e != null)
-                {
-                    try { TaskbarButton.ReleasePointerCapture(e.Pointer); } catch { }
-                }
-                _isDragging = false;
-                _isPotentialDrag = false;
-                _suppressClick = true;
-                SaveWindowState(wasOpen: true);
+                try { TaskbarButton.ReleasePointerCapture(e.Pointer); } catch { }
             }
-            else
-            {
-                _isPotentialDrag = false;
-            }
+
+            CommitDragEnd();
+            _isPotentialDrag = false;
 
             _isPressed = false;
 
@@ -1114,18 +1106,46 @@ namespace FluentSensors.Features.TaskbarWidget
 
         private void TaskbarButton_PointerCaptureLost(object sender, PointerRoutedEventArgs e)
         {
-            _isDragging = false;
-            _isPotentialDrag = false;
-            _suppressClick = false;
+            EndDragOrClearClickGuard();
             TaskbarButton_PointerExited(sender, e);
         }
 
         private void TaskbarButton_PointerCanceled(object sender, PointerRoutedEventArgs e)
         {
+            EndDragOrClearClickGuard();
+            TaskbarButton_PointerExited(sender, e);
+        }
+
+        // the single place a drag is committed; the offset only lives in _currentOffsetDip until this runs
+        //
+        // ButtonBase releases the pointer capture from inside its own PointerReleased class handler, which runs
+        // ahead of our instance handler, so the capture loss can be the first of the two to arrive; whichever gets
+        // here first does the save and the other one finds nothing left to do
+        private void CommitDragEnd()
+        {
+            if (!_isDragging) return;
+
             _isDragging = false;
             _isPotentialDrag = false;
-            _suppressClick = false;
-            TaskbarButton_PointerExited(sender, e);
+            _suppressClick = true;
+            SaveWindowState(wasOpen: true);
+        }
+
+        // a capture loss or cancellation mid drag still ends the drag: the window sits at its new position already,
+        // so the offset is kept rather than dropped
+        // without a drag in flight there is nothing to swallow and the click guard is released instead
+        private void EndDragOrClearClickGuard()
+        {
+            if (_isDragging)
+            {
+                CommitDragEnd();
+            }
+            else
+            {
+                _suppressClick = false;
+            }
+
+            _isPotentialDrag = false;
         }
 
         private void TaskbarButton_Click(object sender, RoutedEventArgs e)

--- a/FluentSensors/Persistence/Models/AppSettingsData.cs
+++ b/FluentSensors/Persistence/Models/AppSettingsData.cs
@@ -66,6 +66,9 @@ namespace FluentSensors.Persistence.Models
 
         public CsvPauseSeam CsvPauseSeam { get; set; } = CsvPauseSeam.Gap;
 
+        // which profile the sensors page opens on; the widget profile is what a fresh install starts with
+        public SensorSelectionProfile LastSensorProfile { get; set; } = SensorSelectionProfile.WidgetWindow;
+
         // lives on HardwareMonitorService at runtime, but conceptually belongs with the rest of the app settings for
         // persistence purposes
         public int UpdateIntervalMs { get; set; } = 500;

--- a/FluentSensors/Persistence/Services/SettingsService.cs
+++ b/FluentSensors/Persistence/Services/SettingsService.cs
@@ -496,6 +496,22 @@ namespace FluentSensors.Persistence.Services
             }
         }
 
+        // the profile the sensors page was last switched to, so it comes back on the same one
+        // read only while the page is being built, which is why it gets by without a change event
+        private SensorSelectionProfile _lastSensorProfile = SensorSelectionProfile.WidgetWindow;
+        public SensorSelectionProfile LastSensorProfile
+        {
+            get => _lastSensorProfile;
+            set
+            {
+                if (_lastSensorProfile != value)
+                {
+                    _lastSensorProfile = value;
+                    SaveDebounced();
+                }
+            }
+        }
+
         // persistence
         // writes every property straight to its backing field, skipping change events and the save trigger; used only
         // once at startup, before any window or listener exists yet
@@ -533,6 +549,7 @@ namespace FluentSensors.Persistence.Services
             _csvDecimalPlaces = data.CsvDecimalPlaces;
             _csvIncludeUnits = data.CsvIncludeUnits;
             _csvPauseSeam = data.CsvPauseSeam;
+            _lastSensorProfile = data.LastSensorProfile;
 
             // lives on HardwareMonitorService at runtime, not here, but shares this settings file
             HardwareMonitorService.Instance.UpdateIntervalMs = data.UpdateIntervalMs;
@@ -575,6 +592,7 @@ namespace FluentSensors.Persistence.Services
                 CsvDecimalPlaces = _csvDecimalPlaces,
                 CsvIncludeUnits = _csvIncludeUnits,
                 CsvPauseSeam = _csvPauseSeam,
+                LastSensorProfile = _lastSensorProfile,
                 UpdateIntervalMs = HardwareMonitorService.Instance.UpdateIntervalMs
             };
         }


### PR DESCRIPTION
## What does this change

Two pieces of state the user sets by hand and that were gone on the next start.

The taskbar widget always reappeared at the far left. The drag offset was only saved from `PointerReleased`, but `ButtonBase` releases the pointer capture inside its own class handler first, and the resulting `PointerCaptureLost` cleared the drag flag without saving. `window-state.json` therefore never held anything but the compile-time default. Both paths now funnel through a single `CommitDragEnd()`, and a capture loss or cancellation counts as a drag end as well, since the window has already moved by then.

The sensors page always opened on the widget profile. The selection is a new persisted setting now, restored while the page is being built so the flyouts explicit `SelectProfile()` still wins over it.

## Checklist

- [x] Builds locally (x64, Release)
- [x] Comments and code are in English